### PR TITLE
bug: test_home_page now passing. All existing test are passing

### DIFF
--- a/shopyo/modules/admin/test_user.py
+++ b/shopyo/modules/admin/test_user.py
@@ -4,8 +4,8 @@ def test_new_user(new_user):
     assert not new_user.is_admin
 
 
-def test_home_page(test_client):
-    response = test_client.get("/")
+def test_home_page(test_client, init_database):
+    response = test_client.get("/",  follow_redirects=True)
     assert response.status_code == 200
 
 


### PR DESCRIPTION
Associated Issue: #199

The `test_home_page` test was failing. It was missing the `init_database` fixture. Also the recent changes redirects the `/` to `/shop/home` so had to add `follow_redirects=True`. Another options is to remove the `follow_redirects=True` and replace `test_client.get("/")` with `test_client.get("/shop/home")`. Not sure which one is preferred.