### PR TITLE
Add `tox` for testing

### DIFF
--- a/sphinx_source/testing.rst
+++ b/sphinx_source/testing.rst
@@ -10,3 +10,26 @@ run in shopyo/shopyo
 .. code:: bash
 
     python -m pytest .
+
+
+Alternatively, you can run your tests via `tox <https://tox.readthedocs.io/en/latest/>`_.
+
+run all tests, for all supported Python interpreters
+
+.. code:: bash
+
+    tox
+
+
+run all tests, on Python 3.8 only
+
+.. code:: bash
+
+    tox -e py38
+
+
+run all only the `test_home_page` test, on Python 3.9 only
+
+.. code:: bash
+
+    tox -e py39 -- -k test_home_page

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py39
+    py38
+    py37
+    py36
+    py35
+    py34
+skip_missing_interpreters=true
+
+[testenv]
+# test setup according to https://www.appinv.science/shopyo/testing.html
+changedir = shopyo
+deps = pytest
+commands = python -m pytest  {posargs}


### PR DESCRIPTION
Now, you can run tests on all supported Python versions via

tox


This fixes #107