### PR TITLE
test: update 1 and add 2 functional tests for admin

### DIFF
--- a/shopyo/conftest.py
+++ b/shopyo/conftest.py
@@ -54,7 +54,7 @@ def init_database():
     # Insert user data
     user1 = User(email="admin1@domain.com")
     user1.set_hash("pass")
-    user2 = User(email="admin2@domain.com")
+    user2 = User(email="admin2@domain.com", is_admin=True)
     user2.set_hash("pass")
     db.session.add(user1)
     db.session.add(user2)

--- a/shopyo/modules/admin/test_user.py
+++ b/shopyo/modules/admin/test_user.py
@@ -8,15 +8,18 @@ def test_new_user(new_user):
     assert new_user.password != "pass"
     assert not new_user.is_admin
 
+
 def test_home_page(test_client, init_database):
     """
-    GIVEN a Flask application configured for testing and an intitail testing database,
+    GIVEN a Flask application configured for testing and an
+    intitail testing database,
     WHEN the '/' page is requested (GET)
     THEN check that the response is valid
     """
     # '/' redirects to /shop/home
     response = test_client.get("/",  follow_redirects=True)
     assert response.status_code == 200
+
 
 def test_valid_login_logout(test_client):
     """
@@ -34,7 +37,7 @@ def test_valid_login_logout(test_client):
 
     # Check if login was successful
     assert response.status_code == 200
-    assert b"Control panel" in response.data  
+    assert b"Control panel" in response.data
 
     # Replace route with url_for. Not working at the moment
     response = test_client.get('/login/logout', follow_redirects=True)
@@ -61,32 +64,34 @@ def test_admin_home_page(test_client):
     # Allow user with admin privilege to a access the admin page
     response = test_client.get("/admin/")
     assert response.status_code == 200
-    assert b"Admin" in response.data 
-    assert b"id" in response.data 
-    assert b"Email" in response.data 
-    assert b"Password" in response.data 
-    assert b"Roles" in response.data 
+    assert b"Admin" in response.data
+    assert b"id" in response.data
+    assert b"Email" in response.data
+    assert b"Password" in response.data
+    assert b"Roles" in response.data
 
     # Login with non-admin credentials
     response = test_client.post(
         "/login/",
         data=dict(email="admin1@domain.com", password="pass"),
         follow_redirects=True,
-    )  
+    )
 
     # Check if login was successful
     assert response.status_code == 200
-        
-    # Redirect user with non-admin privilege 
-    # Note: change this to check if it redirects to dashboard route. 
+
+    # Redirect user with non-admin privilege
+    # Note: change this to check if it redirects to dashboard route.
     response = test_client.get("/admin/")
     # assert request.path == '/dashboard/'
     assert response.status_code == 302
 
+
 def test_admin_sidebar(test_client):
     """
     GIVEN a Flask application configured for testing,
-    WHEN the '/admin/add', '/admin/roles' page are requested (GET) by user with admin privileges
+    WHEN the '/admin/add', '/admin/roles' page are requested (GET) by user with
+    admin privileges
     THEN check that the response is valid
     """
 
@@ -100,7 +105,7 @@ def test_admin_sidebar(test_client):
     # check if login was successful
     assert response.status_code == 200
 
-    # check if add route is working 
+    # check if add route is working
     response = test_client.get("/admin/add")
     assert response.status_code == 200
     assert b"Email" in response.data

--- a/shopyo/modules/admin/test_user.py
+++ b/shopyo/modules/admin/test_user.py
@@ -1,28 +1,119 @@
 def test_new_user(new_user):
+    """
+    GIVEN a User model
+    WHEN a new User is created
+    THEN check the email, password, admin privilege
+    """
     assert new_user.email == "admin3@domain.com"
     assert new_user.password != "pass"
     assert not new_user.is_admin
 
-
 def test_home_page(test_client, init_database):
+    """
+    GIVEN a Flask application configured for testing and an intitail testing database,
+    WHEN the '/' page is requested (GET)
+    THEN check that the response is valid
+    """
+    # '/' redirects to /shop/home
     response = test_client.get("/",  follow_redirects=True)
     assert response.status_code == 200
 
+def test_valid_login_logout(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the logging in and loggoing out from the app
+    THEN check that the response is valid for each case
+    """
 
-def test_valid_login_logout(test_client, init_database):
+    # Login to the app
     response = test_client.post(
         "/login/",
         data=dict(email="admin1@domain.com", password="pass"),
         follow_redirects=True,
     )
-    # print(response.data)
+
+    # Check if login was successful
     assert response.status_code == 200
-    # print(response.data)
-    assert b"panel" in response.data  # still only showing normal login screen
-    # Control panel
-    # response = test_client.get('/logout', follow_redirects=True)
-    # assert response.status_code == 200
+    assert b"Control panel" in response.data  
+
+    # Replace route with url_for. Not working at the moment
+    response = test_client.get('/login/logout', follow_redirects=True)
+    assert response.status_code == 200
 
 
-def test_dashboard(test_client, init_database):
-    pass
+def test_admin_home_page(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the '/admin' page is requested (GET) by user with admin privileges
+    THEN check that the response is valid
+    """
+
+    # Login with admin credentials
+    response = test_client.post(
+        "/login/",
+        data=dict(email="admin2@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # Check if login was successful
+    assert response.status_code == 200
+
+    # Allow user with admin privilege to a access the admin page
+    response = test_client.get("/admin/")
+    assert response.status_code == 200
+    assert b"Admin" in response.data 
+    assert b"id" in response.data 
+    assert b"Email" in response.data 
+    assert b"Password" in response.data 
+    assert b"Roles" in response.data 
+
+    # Login with non-admin credentials
+    response = test_client.post(
+        "/login/",
+        data=dict(email="admin1@domain.com", password="pass"),
+        follow_redirects=True,
+    )  
+
+    # Check if login was successful
+    assert response.status_code == 200
+        
+    # Redirect user with non-admin privilege 
+    # Note: change this to check if it redirects to dashboard route. 
+    response = test_client.get("/admin/")
+    # assert request.path == '/dashboard/'
+    assert response.status_code == 302
+
+def test_admin_sidebar(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the '/admin/add', '/admin/roles' page are requested (GET) by user with admin privileges
+    THEN check that the response is valid
+    """
+
+    # Login with admin credentials
+    response = test_client.post(
+        "/login/",
+        data=dict(email="admin2@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # check if login was successful
+    assert response.status_code == 200
+
+    # check if add route is working 
+    response = test_client.get("/admin/add")
+    assert response.status_code == 200
+    assert b"Email" in response.data
+    assert b"Password" in response.data
+    assert b"First Name" in response.data
+    assert b"Last Name" in response.data
+    assert b"Admin User" in response.data
+
+    # check if the roles route is working
+    response = test_client.get("/admin/roles")
+    assert response.status_code == 200
+    assert b"Roles" in response.data
+
+    # check admin route is still working
+    response = test_client.get("/admin/")
+    assert response.status_code == 200


### PR DESCRIPTION
Add two more functional tests to check admin routes are working. Updated `test_valid_login_logout` with test for logout part. For now I am using hardcoded routes instead of `url_for` as I was having some problem making it work with `pytest`. The home page tests are still in admin module but not sure if we should place them in any other location. In addition, since the fixtures scope is session, we only need to use the `init_database` fixture as argument for the very first functional test that depends on it (`test_home_page` for now)