### PR TITLE
test: add functional tests for category module

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,3 +15,4 @@ black
 isort==5.6.4
 Sphinx==3.2.1
 pytest==6.1.1
+pytest-order

--- a/shopyo/conftest.py
+++ b/shopyo/conftest.py
@@ -10,6 +10,7 @@ from shopyoapi.uploads import add_setting
 
 from modules.admin.models import User
 from modules.settings.models import Settings
+from flask import url_for
 
 # from shopyoapi.cmd import initialise
 
@@ -41,7 +42,7 @@ def test_client():
 
 
 @pytest.fixture(scope="session")
-def init_database():
+def init_database(test_client):
 
     # Create the database and the database table
     db.create_all()
@@ -56,6 +57,7 @@ def init_database():
 
     with open("config.json", "r") as config:
         config = json.load(config)
+
     for name, value in config["settings"].items():
         s = Settings(setting=name, value=value)
         db.session.add(s)
@@ -63,7 +65,36 @@ def init_database():
     # Commit the changes for the users
     db.session.commit()
 
-    # initialise()
-    yield db  # this is where the testing happens!
+    yield db    # this is where the testing happens!
 
-    # db.drop_all()
+    db.drop_all()
+
+
+@pytest.fixture(scope='session')
+def _db(init_database):
+    return init_database
+
+# Want TO USE THE BELOW CODE FOR LOGIN AND LOGOUT
+# TO REMOVE REPEATED CODE FROM ALL TESTS. BUT
+# CURRENTLY FAILING TO MAKE LOGIN WORK FROM OUTSIDE
+# THE TEST FUNCTION
+
+# @pytest.fixture
+# def auth(test_client):
+#     return AuthActions(test_client)
+
+
+# class AuthActions(object):
+#     def __init__(self, client):
+#         self._client = client
+
+#     def login(self, user):
+#         return self._client.post(
+#             url_for("login.login"),
+#             data=dict(email="admin1@domain.com", password="pass"),
+#             follow_redirects=True,
+#         )
+
+    # def logout(self):
+    #     return self._client.get(
+    #         url_for("login.logout"), follow_redirects=True)

--- a/shopyo/modules/admin/test_admin.py
+++ b/shopyo/modules/admin/test_admin.py
@@ -1,0 +1,88 @@
+"""
+This file (test_admin.py) contains the functional tests for
+the `admin` blueprint.
+
+These tests use GETs and POSTs to different endpoints to check
+for the proper behavior of the `admin` blueprint.
+"""
+from flask import url_for, request
+
+
+def test_admin_home_page(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the '/admin' page is requested (GET) by user with admin privileges
+    THEN check that the response is valid
+    """
+
+    # Login with admin credentials
+    response = test_client.post(
+        url_for("login.login"),
+        data=dict(email="admin2@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # Check if login was successful
+    assert response.status_code == 200
+
+    # Allow user with admin privilege to a access the admin page
+    response = test_client.get(url_for("admin.user_list"))
+    assert response.status_code == 200
+    assert b"Admin" in response.data
+    assert b"id" in response.data
+    assert b"Email" in response.data
+    assert b"Password" in response.data
+    assert b"Roles" in response.data
+
+    # Login with non-admin credentials
+    response = test_client.post(
+        url_for("login.login"),
+        data=dict(email="admin1@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # Check if login was successful
+    assert response.status_code == 200
+
+    # Redirect user with non-admin privilege to dashboard
+    response = test_client.get("/admin/", follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for("dashboard.index")
+    assert b"You need to be an admin to view this page" in response.data
+
+
+def test_admin_sidebar(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the '/admin/add', '/admin/roles' page are requested (GET) by user with
+    admin privileges
+    THEN check that the response is valid
+    """
+
+    # Login with admin credentials
+    response = test_client.post(
+        url_for("login.login"),
+        data=dict(email="admin2@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # check if login was successful
+    assert response.status_code == 200
+
+    # check if add route is working
+    response = test_client.get(url_for("admin.user_add"))
+    assert response.status_code == 200
+    assert b"Email" in response.data
+    assert b"Password" in response.data
+    assert b"First Name" in response.data
+    assert b"Last Name" in response.data
+    assert b"Admin User" in response.data
+
+    # check if the roles route is working
+    response = test_client.get(url_for("admin.roles"))
+    assert response.status_code == 200
+    assert b"Roles" in response.data
+
+    # check admin route is still working
+    response = test_client.get(url_for("admin.user_list"))
+    assert response.status_code == 200

--- a/shopyo/modules/admin/test_user.py
+++ b/shopyo/modules/admin/test_user.py
@@ -1,4 +1,5 @@
 from flask import url_for, request
+import pytest
 
 
 def test_new_user(new_user):
@@ -12,6 +13,7 @@ def test_new_user(new_user):
     assert not new_user.is_admin
 
 
+@pytest.mark.order('first')
 def test_home_page(test_client, init_database):
     """
     GIVEN a Flask application configured for testing and an
@@ -24,6 +26,7 @@ def test_home_page(test_client, init_database):
     assert response.status_code == 200
 
 
+@pytest.mark.order('second')
 def test_valid_login_logout(test_client):
     """
     GIVEN a Flask application configured for testing,
@@ -48,83 +51,3 @@ def test_valid_login_logout(test_client):
     assert response.status_code == 200
     assert request.path == url_for('login.login')
     assert b"Successfully logged out" in response.data
-
-
-def test_admin_home_page(test_client):
-    """
-    GIVEN a Flask application configured for testing,
-    WHEN the '/admin' page is requested (GET) by user with admin privileges
-    THEN check that the response is valid
-    """
-
-    # Login with admin credentials
-    response = test_client.post(
-        url_for("login.login"),
-        data=dict(email="admin2@domain.com", password="pass"),
-        follow_redirects=True,
-    )
-
-    # Check if login was successful
-    assert response.status_code == 200
-
-    # Allow user with admin privilege to a access the admin page
-    response = test_client.get(url_for("admin.user_list"))
-    assert response.status_code == 200
-    assert b"Admin" in response.data
-    assert b"id" in response.data
-    assert b"Email" in response.data
-    assert b"Password" in response.data
-    assert b"Roles" in response.data
-
-    # Login with non-admin credentials
-    response = test_client.post(
-        url_for("login.login"),
-        data=dict(email="admin1@domain.com", password="pass"),
-        follow_redirects=True,
-    )
-
-    # Check if login was successful
-    assert response.status_code == 200
-
-    # Redirect user with non-admin privilege to dashboard
-    response = test_client.get("/admin/", follow_redirects=True)
-    assert response.status_code == 200
-    assert request.path == url_for("dashboard.index")
-    assert b"You need to be an admin to view this page" in response.data
-
-
-def test_admin_sidebar(test_client):
-    """
-    GIVEN a Flask application configured for testing,
-    WHEN the '/admin/add', '/admin/roles' page are requested (GET) by user with
-    admin privileges
-    THEN check that the response is valid
-    """
-
-    # Login with admin credentials
-    response = test_client.post(
-        url_for("login.login"),
-        data=dict(email="admin2@domain.com", password="pass"),
-        follow_redirects=True,
-    )
-
-    # check if login was successful
-    assert response.status_code == 200
-
-    # check if add route is working
-    response = test_client.get(url_for("admin.user_add"))
-    assert response.status_code == 200
-    assert b"Email" in response.data
-    assert b"Password" in response.data
-    assert b"First Name" in response.data
-    assert b"Last Name" in response.data
-    assert b"Admin User" in response.data
-
-    # check if the roles route is working
-    response = test_client.get(url_for("admin.roles"))
-    assert response.status_code == 200
-    assert b"Roles" in response.data
-
-    # check admin route is still working
-    response = test_client.get(url_for("admin.user_list"))
-    assert response.status_code == 200

--- a/shopyo/modules/category/test_category.py
+++ b/shopyo/modules/category/test_category.py
@@ -1,0 +1,165 @@
+"""
+This file (test_category.py) contains the functional tests
+for the `category` blueprint.
+
+These tests use GETs and POSTs to different URLs to check
+for the proper behavior of the `category` blueprint.
+"""
+from flask import url_for, request
+from modules.category.models import Category
+
+
+def test_category_dashboard_page(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the category's dashboard page is requested (GET)
+    THEN check that the response is valid
+    """
+    # Logout and try to access the category dashboard. It should redirect
+    response = test_client.get(url_for('login.logout'), follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Successfully logged out" in response.data
+
+    # check request to contact correctly redirects to login page
+    response = test_client.get(
+        url_for('category.dashboard'), follow_redirects=True)
+    assert request.path == url_for('login.login')
+
+    # Login and try to access the category dashboard. It should return OK
+    response = test_client.post(
+        url_for('login.login'),
+        data=dict(email="admin1@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # check if successfully logged in
+    assert response.status_code == 200
+
+    response = test_client.get(url_for('category.dashboard'))
+    assert response.status_code == 200
+    assert b"Category" in response.data
+
+
+def test_category_add_get(test_client, init_database):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN the category's dashboard page is requested (GET)
+    THEN check that the response is valid
+    """
+    # Logout and try to access the category dashboard. It should redirect
+    response = test_client.get(url_for('login.logout'), follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Successfully logged out" in response.data
+
+    # check request to contact correctly redirects to login page
+    response = test_client.get(url_for('category.add'), follow_redirects=True)
+    assert request.path == url_for('login.login')
+
+    # Login and try to access the category dashboard. It should return OK
+    response = test_client.post(
+        url_for('login.login'),
+        data=dict(email="admin1@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+
+    # check if successfully logged in
+    assert response.status_code == 200
+
+    # check add route GET response is valid
+    response = test_client.get(url_for('category.add'))
+    assert response.status_code == 200
+    assert b"name" in response.data
+    assert b"image" in response.data
+
+
+def test_category_add_post_invalid(test_client, init_database):
+    """
+    GIVEN a Flask application configured for testing, and an initial database
+    WHEN the invalid POST requests are made to category add page
+    THEN check that the responses are valid
+    """
+    # should not allow adding empty string category
+    response = test_client.post(
+        url_for('category.add'),
+        data=dict(name="   "),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Category name cannot be empty" in response.data
+
+    # should not allow adding category name "uncategorized"
+    # which is case-insensitive
+    response = test_client.post(
+        url_for('category.add'),
+        data=dict(name=" uncateGoriZed  "),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Category cannot be named as uncategorised" in response.data
+
+    # should not allow adding alternateive spelling of uncategorise
+    response = test_client.post(
+        url_for('category.add'),
+        data=dict(name=" uncategoriseD"),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Category cannot be named as uncategorised" in response.data
+
+    # add a category and then try adding the same one again
+    category = Category(name="test-exiting-category")
+    init_database.session.add(category)
+    assert init_database.session.query(Category).count() == 1
+
+    # should not allow adding category whose name already exists
+    response = test_client.post(
+        url_for('category.add'),
+        data=dict(name="test-exiting-category"),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Category already exists" in response.data
+    assert init_database.session.query(Category).count() == 1
+
+    # remove the added category so it does not affect future tests.
+    # Ideally want to use pytest-flask-sqlalchemy plugin for auto tear
+    # down but currently giving a warning. Also if any of the above
+    # asserts fail then we never reach this code and future tests might
+    # fail as well. NEED TO FIX THIS
+    init_database.session.rollback()
+    assert init_database.session.query(Category).count() == 0
+
+
+def test_category_add_post_valid(test_client, init_database):
+    """
+    GIVEN a Flask application configured for testing, and an initial database
+    WHEN the a valid POST request is made to category add page
+    THEN check that the response is valid
+    """
+    # make sure no category is in database at the start
+    assert init_database.session.query(Category).count() == 0
+
+    # add a valid category
+    response = test_client.post(
+        url_for('category.add'),
+        data=dict(name="test-valid-category-1"),
+        follow_redirects=True,
+    )
+
+    # it should succesfully be added
+    assert response.status_code == 200
+    assert b"Category added successfully" in response.data
+    assert init_database.session.query(Category).count() == 1
+
+    # make sure the correct category exits
+    row = (init_database.session.query(Category).
+           filter(Category.name == 'test-valid-category-1').scalar())
+    assert row.name == 'test-valid-category-1'
+
+    # remove the added category so it does not affect future tests.
+    # Ideally want to use pytest-flask-sqlalchemy plugin for auto tear
+    # down but currently giving a warning. Also if any of the above
+    # asserts fail then we never reach this code and future tests might
+    # fail as well. NEED TO FIX THIS
+    row.delete()
+    assert init_database.session.query(Category).count() == 0

--- a/shopyo/modules/category/view.py
+++ b/shopyo/modules/category/view.py
@@ -64,10 +64,11 @@ def add():
     if request.method == "POST":
         name = request.form["name"]
         if is_empty_str(name):
-            return redirect(url_for("category.dashboard"))
-        if name.strip() == "uncategorised":
+            flash(notify_warning("Category name cannot be empty"))
+            return redirect(url_for("category.add"))
+        if name.strip().lower() == "uncategorised" or name.strip().lower() == "uncategorized":
             flash(notify_warning("Category cannot be named as uncategorised"))
-            return redirect(url_for("category.dashboard"))
+            return redirect(url_for("category.add"))
         has_category = Category.category_exists(name)
         if has_category is False:
             category = Category(name=name)
@@ -88,6 +89,10 @@ def add():
             except flask_uploads.UploadNotAllowed as e:
                 pass
             category.insert()
+            flash(notify_success("Category added successfully"))
+        else:
+            flash(notify_warning("Category already exists"))
+
         return render_template("category/add.html", **context)
 
     context["has_category"] = str(has_category)

--- a/shopyo/modules/category/view.py
+++ b/shopyo/modules/category/view.py
@@ -91,7 +91,8 @@ def add():
             category.insert()
             flash(notify_success("Category added successfully"))
         else:
-            flash(notify_warning("Category already exists"))
+            flash(notify_warning("Category " +
+                  "already exists"))
 
         return render_template("category/add.html", **context)
 

--- a/shopyo/modules/category/view.py
+++ b/shopyo/modules/category/view.py
@@ -66,7 +66,8 @@ def add():
         if is_empty_str(name):
             flash(notify_warning("Category name cannot be empty"))
             return redirect(url_for("category.add"))
-        if name.strip().lower() == "uncategorised" or name.strip().lower() == "uncategorized":
+        if (name.strip().lower() == "uncategorised" or
+                name.strip().lower() == "uncategorized"):
             flash(notify_warning("Category cannot be named as uncategorised"))
             return redirect(url_for("category.add"))
         has_category = Category.category_exists(name)
@@ -91,8 +92,7 @@ def add():
             category.insert()
             flash(notify_success("Category added successfully"))
         else:
-            flash(notify_warning("Category " +
-                  "already exists"))
+            flash(notify_warning("Category already exists"))
 
         return render_template("category/add.html", **context)
 

--- a/shopyo/modules/contact/test_contact.py
+++ b/shopyo/modules/contact/test_contact.py
@@ -1,3 +1,10 @@
+"""
+This file (test_contact.py) contains the functional tests for the
+`contact` blueprint.
+
+These tests use GETs and POSTs to different endpoints to check for
+the proper behavior of the `contact` blueprint.
+"""
 from flask import url_for, request
 
 
@@ -54,6 +61,12 @@ def test_contact_dashboard(test_client):
 
 
 def test_contact_validate_msg(test_client):
+    """
+    GIVEN a Flask application configured for testing,
+    WHEN POST request is made contact validate page
+    THEN check that the response is valid and that
+    the new validated message appears on contact dashboard
+    """
 
     # GET request should fail for validate message
     # Currently test is uncommented since no return statement for

--- a/shopyo/modules/dashboard/test_dashboard.py
+++ b/shopyo/modules/dashboard/test_dashboard.py
@@ -1,4 +1,3 @@
-def test_dashboard(test_client, init_database):
+def test_dashboard(test_client):
     response = test_client.get("/dashboard/", follow_redirects=True)
-    print(response.data)
     assert response.status_code == 200


### PR DESCRIPTION
Added some functional tests for category blueprint. Other additions include:
- flash message for different conditions in category view.py
- Do not allow Category name "uncategorized" (currently only check for the alternate spelling uncategorised) and make the check case insensitive
- moving admin  blueprint test from `test_user.py` to `test_admin.py`

Issue for review to make tests better:
- currently have added same logout and login client code to all tests as we want to make sure we cannot reach the endpoint without login and since the scope of our test_client is "session' we need to manually logout each time for different test that require login. Ideally want to have a helper function to take care of  login/logout via `test_client`. Tried this but pytests gives errors.
- Currently database changes persist through each tests so I manually delete/rollback. Want to use `pytest-flask-sqlalchemy` which makes transcations non-persistent. However, using it gives the following compile time error as described here https://github.com/sqlalchemy/sqlalchemy/issues/5361. 
- Need to consider what happens if one test fail? does it affect other tests? For current tests written it does affect so need more guidance or tip to improve it.
- Still not sure what is the best way to setup the `conftest.py` for our app and database.