### PR TITLE
test: added tests for category delete and bug fixes

### DIFF
--- a/shopyo/conftest.py
+++ b/shopyo/conftest.py
@@ -1,21 +1,20 @@
+"""
+File conftest.py contains pytest fixtures that are used in numerous
+test functions. Refer to https://docs.pytest.org/en/stable/fixture.html
+for more details on pytest
+"""
 import json
 import os
-
 import pytest
 
 from app import create_app
-
-from shopyoapi.init import db
+from shopyoapi.init import db as _db
 from shopyoapi.uploads import add_setting
-
 from modules.admin.models import User
 from modules.settings.models import Settings
-from flask import url_for
-
-# from shopyoapi.cmd import initialise
 
 # run in shopyo/shopyo
-# python -m pytest .
+# python -m pytest . or python -m pytest -v
 
 
 if os.path.exists("testing.db"):
@@ -24,6 +23,9 @@ if os.path.exists("testing.db"):
 
 @pytest.fixture(scope="session")
 def new_user():
+    """
+    A pytest fixture that returns a user model object
+    """
     user = User(email="admin3@domain.com")
     user.set_hash("pass")
     return user
@@ -31,6 +33,9 @@ def new_user():
 
 @pytest.fixture(scope="session")
 def test_client():
+    """
+    setups up and returns the flask testing app
+    """
     flask_app = create_app("testing")
 
     # Create a test client using the Flask application configured for testing
@@ -42,37 +47,61 @@ def test_client():
 
 
 @pytest.fixture(scope="session")
-def init_database(test_client):
-
+def db(test_client):
+    """
+    creates and returns the initial testing database
+    """
     # Create the database and the database table
-    db.create_all()
+    _db.app = test_client
+    _db.create_all()
 
     # Insert user data
     user1 = User(email="admin1@domain.com")
     user1.set_hash("pass")
     user2 = User(email="admin2@domain.com", is_admin=True)
     user2.set_hash("pass")
-    db.session.add(user1)
-    db.session.add(user2)
+    _db.session.add(user1)
+    _db.session.add(user2)
 
+    # add the default settings
     with open("config.json", "r") as config:
         config = json.load(config)
 
     for name, value in config["settings"].items():
         s = Settings(setting=name, value=value)
-        db.session.add(s)
+        _db.session.add(s)
 
     # Commit the changes for the users
-    db.session.commit()
+    _db.session.commit()
 
-    yield db    # this is where the testing happens!
+    yield _db    # this is where the testing happens!
 
-    db.drop_all()
+    _db.drop_all()
 
 
-@pytest.fixture(scope='session')
-def _db(init_database):
-    return init_database
+@pytest.yield_fixture(scope='function', autouse=True)
+def db_session(db):
+    """
+    Creates a new database session for a test. Note you must use this fixture
+    if your test connects to db. Autouse is set to true which implies
+    that the fixture will be setup before each test
+
+    Here we not only support commit calls but also rollback calls in tests.
+    """
+    connection = db.engine.connect()
+    transaction = connection.begin()
+
+    options = dict(bind=connection, binds={})
+    session = db.create_scoped_session(options=options)
+
+    db.session = session
+
+    yield session
+
+    transaction.rollback()
+    connection.close()
+    session.remove()
+
 
 # Want TO USE THE BELOW CODE FOR LOGIN AND LOGOUT
 # TO REMOVE REPEATED CODE FROM ALL TESTS. BUT

--- a/shopyo/modules/admin/test_user.py
+++ b/shopyo/modules/admin/test_user.py
@@ -14,10 +14,10 @@ def test_new_user(new_user):
 
 
 @pytest.mark.order('first')
-def test_home_page(test_client, init_database):
+def test_home_page(test_client, db):
     """
-    GIVEN a Flask application configured for testing and an
-    intitail testing database,
+    GIVEN a Flask application configured for testing and a
+    intitail testing database db,
     WHEN the '/' page is requested (GET)
     THEN check that the response is valid
     """

--- a/shopyo/modules/category/test_category.py
+++ b/shopyo/modules/category/test_category.py
@@ -23,6 +23,7 @@ def test_category_dashboard_page(test_client):
     # check request to category correctly redirects to login page
     response = test_client.get(
         url_for('category.dashboard'), follow_redirects=True)
+    assert response.status_code == 200
     assert request.path == url_for('login.login')
 
     # Login and try to access the category dashboard. It should return OK
@@ -53,6 +54,7 @@ def test_category_add_get(test_client):
 
     # check request to contact correctly redirects to login page
     response = test_client.get(url_for('category.add'), follow_redirects=True)
+    response.status_code == 200
     assert request.path == url_for('login.login')
 
     # Login and try to access the category dashboard. It should return OK
@@ -177,6 +179,7 @@ def test_category_delete_get_valid(test_client, db_session):
     response = test_client.get(
         url_for('category.delete', name="test-delete-category"),
         follow_redirects=True)
+    response.status_code == 200
     assert request.path == url_for('login.login')
 
     # Login and try to access the category delete route. It should return OK

--- a/shopyo/modules/category/test_category.py
+++ b/shopyo/modules/category/test_category.py
@@ -6,7 +6,7 @@ These tests use GETs and POSTs to different URLs to check
 for the proper behavior of the `category` blueprint.
 """
 from flask import url_for, request
-from modules.category.models import Category
+from modules.category.models import Category, SubCategory
 
 
 def test_category_dashboard_page(test_client):
@@ -20,7 +20,7 @@ def test_category_dashboard_page(test_client):
     assert response.status_code == 200
     assert b"Successfully logged out" in response.data
 
-    # check request to contact correctly redirects to login page
+    # check request to category correctly redirects to login page
     response = test_client.get(
         url_for('category.dashboard'), follow_redirects=True)
     assert request.path == url_for('login.login')
@@ -40,7 +40,7 @@ def test_category_dashboard_page(test_client):
     assert b"Category" in response.data
 
 
-def test_category_add_get(test_client, init_database):
+def test_category_add_get(test_client):
     """
     GIVEN a Flask application configured for testing,
     WHEN the category's dashboard page is requested (GET)
@@ -72,9 +72,9 @@ def test_category_add_get(test_client, init_database):
     assert b"image" in response.data
 
 
-def test_category_add_post_invalid(test_client, init_database):
+def test_category_add_post_invalid(test_client, db_session):
     """
-    GIVEN a Flask application configured for testing, and an initial database
+    GIVEN a Flask application configured for testing, and a db session
     WHEN the invalid POST requests are made to category add page
     THEN check that the responses are valid
     """
@@ -108,8 +108,9 @@ def test_category_add_post_invalid(test_client, init_database):
 
     # add a category and then try adding the same one again
     category = Category(name="test-exiting-category")
-    init_database.session.add(category)
-    assert init_database.session.query(Category).count() == 1
+    db_session.add(category)
+    db_session.commit()
+    assert db_session.query(Category).count() == 1
 
     # should not allow adding category whose name already exists
     response = test_client.post(
@@ -118,26 +119,19 @@ def test_category_add_post_invalid(test_client, init_database):
         follow_redirects=True,
     )
     assert response.status_code == 200
-    assert b"Category already exists" in response.data
-    assert init_database.session.query(Category).count() == 1
-
-    # remove the added category so it does not affect future tests.
-    # Ideally want to use pytest-flask-sqlalchemy plugin for auto tear
-    # down but currently giving a warning. Also if any of the above
-    # asserts fail then we never reach this code and future tests might
-    # fail as well. NEED TO FIX THIS
-    init_database.session.rollback()
-    assert init_database.session.query(Category).count() == 0
+    assert (b"Category \"test-exiting-category\" already exists"
+            in response.data)
+    assert db_session.query(Category).count() == 1
 
 
-def test_category_add_post_valid(test_client, init_database):
+def test_category_add_post_valid(test_client, db_session):
     """
-    GIVEN a Flask application configured for testing, and an initial database
+    GIVEN a Flask application configured for testing, and a db session
     WHEN the a valid POST request is made to category add page
     THEN check that the response is valid
     """
     # make sure no category is in database at the start
-    assert init_database.session.query(Category).count() == 0
+    assert db_session.query(Category).count() == 0
 
     # add a valid category
     response = test_client.post(
@@ -148,18 +142,141 @@ def test_category_add_post_valid(test_client, init_database):
 
     # it should succesfully be added
     assert response.status_code == 200
-    assert b"Category added successfully" in response.data
-    assert init_database.session.query(Category).count() == 1
+    assert (b"Category \"test-valid-category-1\" added successfully"
+            in response.data)
+    assert db_session.query(Category).count() == 1
 
     # make sure the correct category exits
-    row = (init_database.session.query(Category).
+    row = (db_session.query(Category).
            filter(Category.name == 'test-valid-category-1').scalar())
     assert row.name == 'test-valid-category-1'
 
-    # remove the added category so it does not affect future tests.
-    # Ideally want to use pytest-flask-sqlalchemy plugin for auto tear
-    # down but currently giving a warning. Also if any of the above
-    # asserts fail then we never reach this code and future tests might
-    # fail as well. NEED TO FIX THIS
-    row.delete()
-    assert init_database.session.query(Category).count() == 0
+
+def test_category_delete_get_valid(test_client, db_session):
+    """
+    GIVEN a Flask application configured for testing, and db session
+    WHEN the valid GET requests are made to category add page
+    THEN check that the responses are valid
+    """
+    # add a category that is to be deleted
+    category = Category(name="test-delete-category")
+    db_session.add(category)
+    db_session.commit()
+    assert db_session.query(Category).count() == 1
+
+    # make sure the correct category exits
+    row = (db_session.query(Category).
+           filter(Category.name == 'test-delete-category').scalar())
+    assert row and row.name == 'test-delete-category'
+
+    # Logout and try to access category delete route. It should redirect
+    response = test_client.get(url_for('login.logout'), follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Successfully logged out" in response.data
+    # Check request to category delete correctly redirects to login page
+    response = test_client.get(
+        url_for('category.delete', name="test-delete-category"),
+        follow_redirects=True)
+    assert request.path == url_for('login.login')
+
+    # Login and try to access the category delete route. It should return OK
+    response = test_client.post(
+        url_for('login.login'),
+        data=dict(email="admin1@domain.com", password="pass"),
+        follow_redirects=True,
+    )
+    # Check if successfully logged in
+    assert response.status_code == 200
+    # after login we should be able to successfully delete category
+    response = test_client.get(
+        url_for('category.delete', name="test-delete-category"),
+        follow_redirects=True)
+    assert (b"Category \"test-delete-category\" sucessfully deleted"
+            in response.data)
+    assert request.path == url_for('category.dashboard')
+    row = (db_session.query(Category).
+           filter(Category.name == 'test-delete-category').scalar())
+    assert not row
+
+
+def test_category_delete_invalid(test_client, db_session):
+    """
+    GIVEN a Flask application configured for testing, and a db session
+    WHEN the invalid GET requests are made to category add page
+    THEN check that the responses are valid
+    """
+    # make sure no category is in database at the start
+    assert db_session.query(Category).count() == 0
+
+    # Should not allow deleteing category named "uncategorised"
+    response = test_client.get(
+        url_for('category.delete', name="uncategorised"),
+        follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for('category.dashboard')
+    assert b"Cannot delete category uncategorised" in response.data
+
+    # Should not allow deleting category with empty name
+    response = test_client.get(
+        url_for('category.delete', name=" "),
+        follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for('category.dashboard')
+    assert b"Cannot delete a category with no name" in response.data
+
+    # Should not allow deleting category that does not exist
+    response = test_client.get(
+        url_for('category.delete', name="test-delete-category"),
+        follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for('category.dashboard')
+    assert (b"Category \"test-delete-category\" does not exist."
+            in response.data)
+
+    # add a category with subcategoires
+    category = Category(name="test-delete-category")
+    subcategory1 = SubCategory(name="test-subcat-1")
+    category.subcategories.append(subcategory1)
+    db_session.add(category)
+    db_session.add(subcategory1)
+    db_session.commit()
+
+    # should not allow deleting a category with subcategories
+    response = test_client.get(
+        url_for('category.delete', name="test-delete-category"),
+        follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for('category.dashboard')
+    assert (b"Please delete all subcategories for category " +
+            b"\"test-delete-category\"" in response.data)
+
+    # Add another subcategory to the same category
+    subcategory2 = SubCategory(name="test-subcat-2")
+    category.subcategories.append(subcategory2)
+    db_session.add(subcategory2)
+    db_session.commit()
+
+    # Still should not allow deleting a category with subcategories
+    response = test_client.get(
+        url_for('category.delete', name="test-delete-category"),
+        follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for('category.dashboard')
+    assert (b"Please delete all subcategories for category " +
+            b"\"test-delete-category\"" in response.data)
+
+    # remove all subcategories
+    db_session.delete(subcategory1)
+    db_session.delete(subcategory2)
+    db_session.commit()
+
+    # should now allow deleting a category with no subcategory
+    response = test_client.get(
+        url_for('category.delete', name="test-delete-category"),
+        follow_redirects=True)
+    assert response.status_code == 200
+    assert request.path == url_for('category.dashboard')
+    assert (b"Category \"test-delete-category\" sucessfully deleted"
+            in response.data)
+    assert db_session.query(Category).count() == 0
+    assert db_session.query(SubCategory).count() == 0

--- a/shopyo/modules/category/view.py
+++ b/shopyo/modules/category/view.py
@@ -90,9 +90,9 @@ def add():
             except flask_uploads.UploadNotAllowed as e:
                 pass
             category.insert()
-            flash(notify_success("Category added successfully"))
+            flash(notify_success(f"Category \"{name}\" added successfully"))
         else:
-            flash(notify_warning("Category already exists"))
+            flash(notify_warning(f"Category \"{name}\" already exists"))
 
         return render_template("category/add.html", **context)
 
@@ -104,23 +104,32 @@ def add():
 @login_required
 def delete(name):
 
+    if is_empty_str(name):
+        flash(notify_warning(f"Cannot delete a category with no name"))
+        return redirect(url_for("category.dashboard"))
+
     if name != "uncategorised":
 
         category = Category.query.filter(Category.name == name).first()
 
-        if len(category.subcategories) != 0:
+        if not category:
+            flash(notify_warning(f"Category \"{name}\" does not exist."))
+            return redirect(url_for("category.dashboard"))
+
+        if category.subcategories:
             flash(
                 notify_warning(
-                    "please delete all subcategories for category".format(name)
+                    f"Please delete all subcategories for category \"{name}\""
                 )
             )
-            return url_for("category.dashboard")
+            return redirect(url_for("category.dashboard"))
 
         category.delete()
+        flash(notify_success(f"Category \"{name}\" sucessfully deleted"))
         return redirect(url_for("category.dashboard"))
-    else:
-        flash(notify_warning("Cannot delete category uncategorised"))
-        return redirect(url_for("category.dashboard"))
+
+    flash(notify_warning("Cannot delete category uncategorised"))
+    return redirect(url_for("category.dashboard"))
 
 
 @module_blueprint.route("/<category_name>/img/<filename>/delete", methods=["GET"])


### PR DESCRIPTION
1- Added two tests for testing the delete route for category.
2- fixed the bug #233 as it came up in the tests written
3- Updated `conftest.py` so now we have separate database session for each test. This solves the problem of persistent databases changes across the tests as discussed in #229. Thus no need for `pytest-flask-sqlalchemy` at least for now
