### PR TITLE
tests: fix tests that were failing.

### DIFF
--- a/shopyo/modules/box__bizhelp/contact/test_contact.py
+++ b/shopyo/modules/box__bizhelp/contact/test_contact.py
@@ -15,8 +15,7 @@ def test_contact_page(test_client):
     WHEN the /contact page is requested (GET)
     THEN check that the response is valid
     """
-
-    response = test_client.get(url_for("contact.index"))
+    response = test_client.get("/contact/")
     assert response.status_code == 200
     assert b"Name" in response.data
     assert b"Email" in response.data
@@ -30,11 +29,11 @@ def test_contact_dashboard(test_client):
     WHEN the /contact/dashboard page is requested (GET)
     THEN check that the response is valid
     """
-
     # Logout and try to access the contact dashboard. It should redirect
     response = test_client.get(url_for("login.logout"), follow_redirects=True)
+    print(request.path)
     assert response.status_code == 200
-    assert b"Successfully logged out" in response.data
+    assert request.path == url_for("login.login")
 
     # check request to contact correctly redirects to login page
     response = test_client.get("/contact/dashboard", follow_redirects=True)
@@ -68,7 +67,6 @@ def test_contact_validate_msg(test_client):
     THEN check that the response is valid and that
     the new validated message appears on contact dashboard
     """
-
     # GET request should fail for validate message
     # Currently test is uncommented since no return statement for
     # validate_message for GET

--- a/shopyo/modules/box__default/admin/test_admin.py
+++ b/shopyo/modules/box__default/admin/test_admin.py
@@ -15,7 +15,6 @@ def test_admin_home_page(test_client):
     WHEN the '/admin' page is requested (GET) by user with admin privileges
     THEN check that the response is valid
     """
-
     # Login with admin credentials
     response = test_client.post(
         url_for("login.login"),
@@ -59,7 +58,6 @@ def test_admin_sidebar(test_client):
     admin privileges
     THEN check that the response is valid
     """
-
     # Login with admin credentials
     response = test_client.post(
         url_for("login.login"),

--- a/shopyo/modules/box__default/admin/test_user.py
+++ b/shopyo/modules/box__default/admin/test_user.py
@@ -16,11 +16,9 @@ def test_new_user(new_user):
 
 
 @pytest.mark.order("first")
-def test_home_page(test_client, db):
-
+def test_home_page(test_client):
     """
-    GIVEN a Flask application configured for testing and a
-    intitail testing database db,
+    GIVEN a Flask application configured for testing,
     WHEN the '/' page is requested (GET)
     THEN check that the response is valid
     """
@@ -29,14 +27,12 @@ def test_home_page(test_client, db):
     assert response.status_code == 200
 
 
-@pytest.mark.order("second")
 def test_valid_login_logout(test_client):
     """
     GIVEN a Flask application configured for testing,
     WHEN the logging in and loggoing out from the app
     THEN check that the response is valid for each case
     """
-
     # Login to the app
     response = test_client.post(
         url_for("login.login"),

--- a/shopyo/modules/box__ecommerce/category/test_category.py
+++ b/shopyo/modules/box__ecommerce/category/test_category.py
@@ -19,7 +19,7 @@ def test_category_dashboard_page(test_client):
     # Logout and try to access the category dashboard. It should redirect
     response = test_client.get(url_for("login.logout"), follow_redirects=True)
     assert response.status_code == 200
-    assert b"Successfully logged out" in response.data
+    assert request.path == url_for("login.login")
 
     # check request to category correctly redirects to login page
     response = test_client.get(
@@ -38,6 +38,7 @@ def test_category_dashboard_page(test_client):
     # check if successfully logged in
     assert response.status_code == 200
 
+    # After successfull login, category dashboard can be accessed
     response = test_client.get(url_for("category.dashboard"))
     assert response.status_code == 200
     assert b"Category" in response.data
@@ -52,7 +53,7 @@ def test_category_add_get(test_client):
     # Logout and try to access the category dashboard. It should redirect
     response = test_client.get(url_for("login.logout"), follow_redirects=True)
     assert response.status_code == 200
-    assert b"Successfully logged out" in response.data
+    assert request.path == url_for("login.login")
 
     # check request to contact correctly redirects to login page
     response = test_client.get(url_for("category.add"), follow_redirects=True)
@@ -181,7 +182,7 @@ def test_category_delete_get_valid(test_client, db_session):
     # Logout and try to access category delete route. It should redirect
     response = test_client.get(url_for("login.logout"), follow_redirects=True)
     assert response.status_code == 200
-    assert b"Successfully logged out" in response.data
+    assert request.path == url_for("login.login")
     # Check request to category delete correctly redirects to login page
     response = test_client.get(
         url_for("category.delete", name="test-delete-category"),


### PR DESCRIPTION
Related to #238

Two tests for contact page that were failing in commit 5f7446f0f56529788e24d613047174eb20523aad are now fixed.
Issue was that the tests that were failing were assuming that user was logged in (which was not the case) and so logging out again did not display the flask logout message. Thus, to make the test robust, removed this assert to check the flask messaged `"Successfully logged out"` and instead replaced with an assert to check that request correctly redirects to login page by comparing the request path