### PR TITLE
fix: update tox to fix test warning. add tox to dev_requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -16,3 +16,4 @@ isort==5.6.4
 Sphinx==3.2.1
 pytest==6.1.1
 pytest-order
+tox

--- a/shopyo/__init__.py
+++ b/shopyo/__init__.py
@@ -1,2 +1,2 @@
-version_info = (3, 3, 6)
+version_info = (3, 3, 7)
 __version__ = ".".join([str(v) for v in version_info])

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ envlist =
     py38
     py37
     py36
-    py35
-    py34
 skip_missing_interpreters=true
 
 [testenv]
 # test setup according to https://www.appinv.science/shopyo/testing.html
 changedir = shopyo
-deps = pytest
+deps = 
+    pytest 
+    pytest-order
 commands = python -m pytest  {posargs}

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"python.pythonPath": "c:\\Users\\shams\\Documents\\venvs\\shopyo\\Scripts\\python.exe",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true
+		
+	}
+}


### PR DESCRIPTION
-add `tox` to `dev_requirements.txt`
-add `pytest-order` to remove tox test warning