### PR TITLE
fix: add the SERVER_NAME in test config to allow url_for to be used

### DIFF
--- a/shopyo/__init__.py
+++ b/shopyo/__init__.py
@@ -1,2 +1,2 @@
-version_info = (3, 3, 7)
+version_info = (3, 3, 8)
 __version__ = ".".join([str(v) for v in version_info])

--- a/shopyo/config.py
+++ b/shopyo/config.py
@@ -39,7 +39,7 @@ class TestingConfig(Config):
     DEBUG = True
     LIVESERVER_PORT = 8943
     LIVESERVER_TIMEOUT = 10
-
+    SERVER_NAME = "localhost.com"
     BCRYPT_LOG_ROUNDS = 4
     TESTING = True
     WTF_CSRF_ENABLED = False


### PR DESCRIPTION
Was getting error if you ran a single test and used url_for when using app_context. According to the doc, we need to set SERVER_NAME in the Configuration.