### PR TITLE
fix: added pycodestyle which was missing from dev_req

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -17,3 +17,4 @@ Sphinx==3.2.1
 pytest==6.1.1
 pytest-order
 tox
+pycodestyle

--- a/shopyo/__init__.py
+++ b/shopyo/__init__.py
@@ -1,2 +1,2 @@
-version_info = (3, 3, 7)
+version_info = (3, 3, 9)
 __version__ = ".".join([str(v) for v in version_info])


### PR DESCRIPTION
Added the `pycodetyle` (previously known as PEP8) which was missing in `dev_requirments.txt`. Allows for local linting check before making a PR.