### PR TITLE
refactor: admin test with less code and easier to read

### DIFF
--- a/shopyo/modules/box__default/admin/tests/test_admin.py
+++ b/shopyo/modules/box__default/admin/tests/test_admin.py
@@ -132,11 +132,11 @@ class TestAdminAPI:
             .scalar()
         )
 
-        assert test_user
+        assert test_user is not None
         assert test_user.first_name == "Test"
         assert test_user.last_name == "User"
-        assert not test_user.is_admin
-        assert test_user.roles
+        assert test_user.is_admin is False
+        assert test_user.roles is not None
         assert len(test_user.roles) == 2
         assert role1.users[0].email == "test@gmail.com"
         assert role2.users[0].email == "test@gmail.com"
@@ -165,7 +165,7 @@ class TestAdminAPI:
         )
 
         assert response.status_code == 200
-        assert b"User with same email already exists"
+        assert b"User with same email already exists" in response.data
         assert test_users == 1
 
     def test_admin_delete_existing_user_get(self, test_client, db_session):
@@ -191,12 +191,13 @@ class TestAdminAPI:
         )
         user_role = (
             db_session.query(role_user_link).join(User).join(Role)
-            .filter(User.id == user.id).all()
+            .filter(User.id == user.id)
+            .scalar()
         )
 
         assert response.status_code == 200
-        assert not test_user
-        assert not user_role
+        assert test_user is None
+        assert user_role is None
         assert test_roles == 2
 
     def test_admin_delete_nonexisting_user_get(self, test_client):
@@ -206,7 +207,7 @@ class TestAdminAPI:
         )
 
         assert response.status_code == 200
-        assert b"Unable to delete. Invalid user id"
+        assert b"Unable to delete. Invalid user id" in response.data
 
     def test_admin_roles_get(self, test_client):
         response = test_client.get(module_info['url_prefix'] + "/roles")

--- a/shopyo/modules/box__default/admin/tests/test_admin.py
+++ b/shopyo/modules/box__default/admin/tests/test_admin.py
@@ -5,253 +5,211 @@ the `admin` blueprint.
 These tests use GETs and POSTs to different endpoints to check
 for the proper behavior of the `admin` blueprint.
 """
+import os
+import json
 from flask import request
 from flask import url_for
+import pytest
 from modules.box__default.admin.models import Role
 from modules.box__default.admin.models import User
 from modules.box__default.admin.models import role_user_link
 
 
-def test_admin_home_page(test_client, auth, admin_user, non_admin_user):
+dirpath = os.path.dirname(os.path.abspath(__file__))
+module_path = os.path.dirname(dirpath)
+
+module_info = None
+module_prefix = "/"
+
+with open(os.path.join(module_path, 'info.json')) as f:
+    module_info = json.load(f)
+    module_prefix = module_info['url_prefix']
+
+
+class TestAdminInvalidAuth:
     """
-    GIVEN a Flask application configured for testing, an admin user,
-    and a non admin user
-    WHEN the '/admin' page is requested (GET) by user with admin privileges
-    THEN check that the response is valid
+    Test all routes for correct user authentication
     """
-    # logout
-    auth.logout()
+    routes_get = [
+        "/", "/add", "/delete/<id>", "/edit/<id>",
+        "/roles", "/roles/<role_id>/delete",
+    ]
 
-    # Accessing admin paged without login should redirect
-    response = test_client.get(
-        url_for("admin.user_list"), follow_redirects=True
-    )
-    assert response.status_code == 200
-    assert request.path == url_for("login.login")
+    routes_post = [
+        "/update", "/roles/update", "/roles/add", "/add"
+    ]
 
-    # Login with admin credentials
-    auth.login(admin_user)
+    @pytest.mark.parametrize('route', routes_get)
+    def test_redirect_if_not_logged_in_get(self, test_client, route, auth):
+        auth.logout()
+        response = test_client.get(
+            module_info['url_prefix'] + route, follow_redirects=True
+        )
 
-    # Allow user with admin privilege to a access the admin page
-    response = test_client.get(url_for("admin.user_list"))
-    assert response.status_code == 200
-    assert b"Admin" in response.data
-    assert b"id" in response.data
-    assert b"Email" in response.data
-    assert b"Password" in response.data
-    assert b"Roles" in response.data
+        assert response.status_code == 200
+        assert request.path == url_for("login.login")
 
-    # Login with non-admin credentials
-    auth.login(non_admin_user)
+    @pytest.mark.parametrize('route', routes_post)
+    def test_redirect_if_not_logged_in_post(self, test_client, route, auth):
+        auth.logout()
+        response = test_client.post(
+            module_info['url_prefix'] + route, follow_redirects=True
+        )
 
-    # Redirect user with non-admin privilege to dashboard
-    response = test_client.get(
-        url_for("admin.user_list"), follow_redirects=True
-    )
-    assert response.status_code == 200
-    assert request.path == url_for("dashboard.index")
-    assert b"You need to be an admin to view this page" in response.data
+        assert response.status_code == 200
+        assert request.path == url_for("login.login")
 
+    @pytest.mark.usefixtures("login_non_admin_user")
+    @pytest.mark.parametrize('route', routes_get)
+    def test_redirect_if_not_admin_get(self, test_client, route):
+        response = test_client.get(
+            module_info['url_prefix'] + route, follow_redirects=True
+        )
 
-def test_admin_add_get(test_client, admin_user, non_admin_user, auth):
-    """
-    GIVEN a Flask application configured for testing, an admin user,
-    a non admin user, and auth class for user login and logout
-    WHEN the '/admin/add', '/admin/roles' page are requested (GET) by user with
-    admin privileges
-    THEN check that the response is valid
-    """
-    # Access to admin add route should not be allowed if not logged in
-    auth.logout()
-    response = test_client.get(
-        url_for("admin.user_add"), follow_redirects=True
-    )
-    assert response.status_code == 200
-    assert request.path == url_for("login.login")
+        assert response.status_code == 200
+        assert request.path == url_for("dashboard.index")
+        assert b"You need to be an admin to view this page" in response.data
 
-    # Login with non admin should not allow accessing the admin add
-    auth.login(non_admin_user)
-    response = test_client.get(
-        url_for("admin.user_add"), follow_redirects=True
-    )
-    assert response.status_code == 200
-    assert request.path == url_for("dashboard.index")
+    @pytest.mark.usefixtures("login_non_admin_user")
+    @pytest.mark.parametrize('route', routes_post)
+    def test_redirect_if_not_admin_post(self, test_client, route):
+        response = test_client.post(
+            module_info['url_prefix'] + route, follow_redirects=True
+        )
 
-    # Login with admin credentials
-    auth.login(admin_user)
-
-    # check if add route is working
-    response = test_client.get(url_for("admin.user_add"))
-    assert response.status_code == 200
-    assert b"Email" in response.data
-    assert b"Password" in response.data
-    assert b"First Name" in response.data
-    assert b"Last Name" in response.data
-    assert b"Admin User" in response.data
+        assert response.status_code == 200
+        assert request.path == url_for("dashboard.index")
+        assert b"You need to be an admin to view this page" in response.data
 
 
-def test_admin_add_post(test_client, admin_user, auth, db_session):
-    """
-    GIVEN a Flask application configured for testing, a non admin user
-    auth class for user login and logout, and a database session,
-    WHEN making POST request to add users to admin route
-    THEN check that the response is valid for different cases
-    """
-    # login with admin user
-    auth.login(admin_user)
+@pytest.mark.usefixtures("login_admin_user")
+class TestAdminAPI:
 
-    # create a role
-    assert db_session.query(Role).count() == 0
-    role1 = Role(name="test1-role")
-    role2 = Role(name="test2-role")
-    db_session.add(role1)
-    db_session.add(role2)
-    db_session.commit()
-    assert db_session.query(Role).count() == 2
+    def test_admin_user_list_get(self, test_client):
+        response = test_client.get(module_info['url_prefix'] + "/")
 
-    # intialize the data that will be posted
-    data = {
-        "email": "test@gmail.com",
-        "password": "pass",
-        "first_name": "Test",
-        "last_name": "User",
-        "is_admin": "",
-        "role_" + str(role1.id): "",
-        "role_" + str(role2.id): ""
-    }
+        assert response.status_code == 200
+        assert b"Admin" in response.data
+        assert b"id" in response.data
+        assert b"Email" in response.data
+        assert b"Password" in response.data
+        assert b"Roles" in response.data
 
-    # Do POST request to add the test user
-    # with the two roles initialized above
-    response = test_client.post(
-        url_for("admin.user_add"),
-        data=data,
-        follow_redirects=True
-    )
+    def test_admin_add_get(self, test_client):
+        response = test_client.get(module_info['url_prefix'] + "/add")
 
-    # check if the user and roles are correctly added
-    test_user = (
-        db_session.query(User)
-        .filter(User.email == "test@gmail.com")
-        .scalar()
-    )
-    assert test_user and test_user.first_name == "Test"
-    assert test_user.last_name == "User"
-    assert not test_user.is_admin
-    assert test_user.roles and len(test_user.roles) == 2
-    assert role1.users[0].email == "test@gmail.com"
-    assert role2.users[0].email == "test@gmail.com"
+        assert response.status_code == 200
+        assert b"Email" in response.data
+        assert b"Password" in response.data
+        assert b"First Name" in response.data
+        assert b"Last Name" in response.data
+        assert b"Admin User" in response.data
 
-    # Should not allow adding the same user again
-    response = test_client.post(
-        url_for("admin.user_add"),
-        data=data,
-        follow_redirects=True
-    )
-    test_users = (
-        db_session.query(User)
-        .filter(User.email == "test@gmail.com")
-        .count()
-    )
-    assert response.status_code == 200
-    assert b"User with same email already exists"
-    assert test_users == 1
+    def test_admin_add_post_unique_user(self, test_client, db_session):
+        role1 = Role(name="test1-role")
+        role2 = Role(name="test2-role")
+        db_session.add(role1)
+        db_session.add(role2)
+        db_session.commit()
+        data = {
+            "email": "test@gmail.com",
+            "password": "pass",
+            "first_name": "Test",
+            "last_name": "User",
+            "is_admin": "",
+            "role_" + str(role1.id): "",
+            "role_" + str(role2.id): ""
+        }
 
+        test_client.post(
+            module_info['url_prefix'] + "/add",
+            data=data,
+            follow_redirects=True
+        )
+        test_user = (
+            db_session.query(User)
+            .filter(User.email == "test@gmail.com")
+            .scalar()
+        )
 
-def test_admin_delete(test_client, new_user, admin_user,
-                      non_admin_user, db_session, auth):
+        assert test_user
+        assert test_user.first_name == "Test"
+        assert test_user.last_name == "User"
+        assert not test_user.is_admin
+        assert test_user.roles
+        assert len(test_user.roles) == 2
+        assert role1.users[0].email == "test@gmail.com"
+        assert role2.users[0].email == "test@gmail.com"
 
-    # create test users with roles
-    assert db_session.query(Role).count() == 0
-    role1 = Role(name="test1-role")
-    role2 = Role(name="test2-role")
-    new_user.roles = [role1, role2]
-    db_session.add(new_user)
-    db_session.commit()
-    user_role = (
-        db_session.query(role_user_link).join(User).join(Role)
-        .filter(User.id == new_user.id).count()
-    )
-    assert db_session.query(Role).count() == 2
-    assert role1.users[0].email == new_user.email
-    assert role2.users[0].email == new_user.email
-    assert user_role == 2
+    def test_admin_add_post_existing_user(self, test_client, db_session):
+        user = User(email="test@gmail.com", password="pass")
+        db_session.add(user)
+        db_session.commit()
+        data = {
+            "email": "test@gmail.com",
+            "password": "pass",
+            "first_name": "Test",
+            "last_name": "User",
+            "is_admin": "",
+        }
 
-    # Logout the current user
-    auth.logout()
+        response = test_client.post(
+            module_info['url_prefix'] + "/add",
+            data=data,
+            follow_redirects=True
+        )
+        test_users = (
+            db_session.query(User)
+            .filter(User.email == "test@gmail.com")
+            .count()
+        )
 
-    # Accesing the admin delete without login should redirect
-    response = test_client.get(
-        url_for("admin.admin_delete", id=new_user.id), follow_redirects=True
-    )
-    assert response.status_code == 200
-    assert request.path == url_for("login.login")
+        assert response.status_code == 200
+        assert b"User with same email already exists"
+        assert test_users == 1
 
-    # Non admin user should not allow accessing the admin delete
-    # Login with non-admin credentials
-    auth.login(non_admin_user)
+    def test_admin_delete_existing_user_get(self, test_client, db_session):
+        user = User(email="test@gmail.com", password="pass")
+        role1 = Role(name="test1-role")
+        role2 = Role(name="test2-role")
+        user.roles = [role1, role2]
 
-    # Redirect user with non-admin privilege to dashboard
-    response = test_client.get(
-        url_for("admin.admin_delete", id=new_user.id), follow_redirects=True
-    )
-    assert response.status_code == 200
-    assert request.path == url_for("dashboard.index")
+        db_session.add(user)
+        db_session.commit()
+        response = test_client.get(
+            module_info['url_prefix'] + "/delete/" + user.id,
+            follow_redirects=True
+        )
+        test_user = (
+            db_session.query(User)
+            .filter(User.email == user.email)
+            .scalar()
+        )
+        test_roles = (
+            db_session.query(Role)
+            .count()
+        )
+        user_role = (
+            db_session.query(role_user_link).join(User).join(Role)
+            .filter(User.id == user.id).all()
+        )
 
-    # login with admin
-    auth.login(admin_user)
-    response = test_client.get(url_for("admin.admin_delete", id=new_user.id))
+        assert response.status_code == 200
+        assert not test_user
+        assert not user_role
+        assert test_roles == 2
 
-    # Get the user with the email of the new user that was just deleted
-    test_user = (
-        db_session.query(User)
-        .filter(User.email == new_user.email)
-        .scalar()
-    )
+    def test_admin_delete_nonexisting_user_get(self, test_client):
+        response = test_client.get(
+            module_info['url_prefix'] + "/delete/some_id",
+            follow_redirects=True
+        )
 
-    # Get the number of roles in the db for this session
-    test_roles = (
-        db_session.query(Role)
-        .count()
-    )
+        assert response.status_code == 200
+        assert b"Unable to delete. Invalid user id"
 
-    # Get all entires for the new user in the Role to User
-    # two way mapping helper table
-    user_role = (
-        db_session.query(role_user_link).join(User).join(Role)
-        .filter(User.id == new_user.id).all()
-    )
+    def test_admin_roles_get(self, test_client):
+        response = test_client.get(module_info['url_prefix'] + "/roles")
 
-    # make sure user is deleted but the role is still present
-    assert not test_user and test_roles == 2
-    # make sure not mappings in the helper table exists
-    # since all the previous mappings were related to
-    # the
-    assert not user_role
-
-
-def test_admin_roles_get(test_client, admin_user, non_admin_user, auth):
-    """
-    GIVEN a Flask application configured for testing, an admin user
-    a non admin user, and an auth class for user login and logout,
-    WHEN making GET request to roles route
-    THEN check that the response is valid
-    """
-    # Access to admin roles route should not be allowed if not logged in
-    auth.logout()
-    response = test_client.get(url_for("admin.roles"), follow_redirects=True)
-    assert response.status_code == 200
-    assert request.path == url_for("login.login")
-
-    # Login with non admin user
-    auth.login(non_admin_user)
-    response = test_client.get(url_for("admin.roles"), follow_redirects=True)
-    assert response.status_code == 200
-    assert request.path == url_for("dashboard.index")
-
-    # Login with admin credentials
-    auth.login(admin_user)
-
-    # check if the roles route is working
-    response = test_client.get(url_for("admin.roles"))
-    assert response.status_code == 200
-    assert b"Roles" in response.data
+        assert response.status_code == 200
+        assert b"Roles" in response.data

--- a/shopyo/modules/box__default/admin/view.py
+++ b/shopyo/modules/box__default/admin/view.py
@@ -24,6 +24,7 @@ from modules.box__default.admin.admin import admin_required
 from modules.box__default.admin.models import Role
 from modules.box__default.admin.models import User
 from shopyoapi.html import notify_warning
+from shopyoapi.html import notify_success
 
 dirpath = os.path.dirname(os.path.abspath(__file__))
 module_info = {}
@@ -114,7 +115,13 @@ def admin_delete(id):
 
     """
     user = User.query.get(id)
+
+    if not user:
+        flash(notify_warning("Unable to delete. Invalid user id"))
+        return redirect("/admin")
+
     user.delete()
+    flash(notify_success("User successfully deleted"))
     return redirect("/admin")
 
 


### PR DESCRIPTION
Associated issue #287 

- use pytest parametrize input to check login_required and admin_required
- break tests to have somewhat arrange, act, and assert structure to make it easier to read
- rename functions such that doc strings are not needed 