### PR TITLE
fix: delete category name with hyphen(-)

### DIFF
--- a/shopyo/__init__.py
+++ b/shopyo/__init__.py
@@ -1,2 +1,2 @@
-version_info = (3, 4, 2)
+version_info = (3, 4, 3)
 __version__ = ".".join([str(v) for v in version_info])

--- a/shopyo/modules/box__ecommerce/category/templates/category/dashboard.html
+++ b/shopyo/modules/box__ecommerce/category/templates/category/dashboard.html
@@ -21,7 +21,7 @@ $(function() {
     $('.delete_me').click(function() {
         var id = $(this).attr('id');
         console.log(id);
-        var name = id.split('-')[1];
+        var name = id.split('-').slice(1).join('-');
         console.log(name);
         var ask = confirm("Do you want to delete ?");
         if (ask === true) {


### PR DESCRIPTION
fix for #312 
minor edit to get rest of category name after splitting by "-".