### PR TITLE
refactor: add clean before initializing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,11 @@ parsers:
       method: no
       macro: no
 base: "parent"
+
+ignore:
+  - "manage.py"  # ignore folders and all its contents
+  - "__init__.py"
+
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ script:
     - cd shopyo
     - echo 'Running Tests....'
     - coverage run --branch --source . -m pytest
+    - coverage report
 after_success:
     - codecov   # submit coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+base: "parent"
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/shopyo/manage.py
+++ b/shopyo/manage.py
@@ -20,6 +20,7 @@ def runserver():
 def process(args):
     printinfo()
     if args[0] == "initialise" or args[0] == "initialize":
+        clean()
         autoload_models()
         initialise()
     elif args[0] == "clean":

--- a/shopyo/shopyoapi/cmd.py
+++ b/shopyo/shopyoapi/cmd.py
@@ -17,6 +17,10 @@ from shopyoapi.cmd_helper import remove_file_or_dir
 from .file import trymkdir
 from .file import trymkfile
 
+# Move this to some where else. Placed here more now
+SEP_CHAR = "#"
+SEP_NUM = 23
+
 
 def clean():
     """
@@ -35,6 +39,9 @@ def clean():
 
     """
     # getting app context creates the shopyo.db file even if it is not present
+    print("Cleaning")
+    print(SEP_CHAR * SEP_NUM, end="\n\n")
+
     with app.test_request_context():
         db.drop_all()
         db.engine.execute('DROP TABLE IF EXISTS alembic_version;')
@@ -59,13 +66,10 @@ def initialise():
 
 
     """
-    SEP_CHAR = "#"
-    SEP_NUM = 23
-
     with open("config.json", "r") as config:
         config = json.load(config)
 
-    print("Creating Db")
+    print("\nCreating Db")
     print(SEP_CHAR * SEP_NUM, end="\n\n")
     subprocess.run(
         [sys.executable, "manage.py", "db", "init"], stdout=subprocess.PIPE
@@ -80,7 +84,7 @@ def initialise():
         [sys.executable, "manage.py", "db", "upgrade"], stdout=subprocess.PIPE
     )
 
-    print("Initialising User")
+    print("\nInitialising User")
     print(SEP_CHAR * SEP_NUM, end="\n\n")
     add_admin(config["admin_user"]["email"], config["admin_user"]["password"])
 

--- a/shopyo/shopyoapi/database.py
+++ b/shopyo/shopyoapi/database.py
@@ -11,7 +11,8 @@ def autoload_models():
     -------
     None
     """
-    print("Auto importing models")
+    print("\nAuto importing models")
+    print("#" * 23, end="\n\n")
     for folder in os.listdir("modules"):
         if folder.startswith("__"):
             continue

--- a/shopyo/shopyoapi/tests/test_cmd.py
+++ b/shopyo/shopyoapi/tests/test_cmd.py
@@ -23,7 +23,7 @@ class TestCommandlineClean:
         )
 
         assert os.path.exists("__pycache__") is False
-        assert captured.out == expected
+        assert expected in captured.out
 
     def test_clean_pycache_in_one_level_below_cwd(self, tmpdir, capfd):
         path = tmpdir.mkdir("shopyo")
@@ -39,7 +39,7 @@ class TestCommandlineClean:
         )
 
         assert os.path.exists(pycache_path) is False
-        assert captured.out == expected
+        assert expected in captured.out
 
     def test_clean_pycache_in_multiple_levels_below_cwd(self, tmpdir, capfd):
         path = tmpdir.mkdir("shopyo").mkdir("shopyo").mkdir("mod").mkdir("box")
@@ -55,7 +55,7 @@ class TestCommandlineClean:
         )
 
         assert os.path.exists(pycache_path) is False
-        assert captured.out == expected
+        assert expected in captured.out
 
     def test_clean_multiple_pycache_in_nested_directories(self, tmpdir, capfd):
         path1 = tmpdir.mkdir("__pycache__")
@@ -74,7 +74,7 @@ class TestCommandlineClean:
         assert os.path.exists(path1) is False
         assert os.path.exists(path2) is False
         assert os.path.exists(path3) is False
-        assert captured.out == expected
+        assert expected in captured.out
 
     def test_no_clean_applied_on_multiple_pycache(self, tmpdir, capfd):
         path1 = tmpdir.mkdir("__pycache__")
@@ -99,7 +99,7 @@ class TestCommandlineClean:
         )
 
         assert os.path.exists(shopyo_db) is False
-        assert captured.out == expected
+        assert expected in captured.out
 
     def test_clean_on_migration_folder(self, tmpdir, capfd):
         migrations_path = tmpdir.mkdir("migrations")
@@ -114,7 +114,7 @@ class TestCommandlineClean:
         )
 
         assert os.path.exists(migrations_path) is False
-        assert captured.out == expected
+        assert expected in captured.out
 
     def test_no_clean_on_shopyo_and_migrations(self, tmpdir):
         migrations_path = tmpdir.mkdir("migrations")
@@ -135,6 +135,6 @@ class TestCommandlineClean:
             "[ ] file/folder 'migrations' doesn't exist\n"
         )
 
-        assert captured.out == expected
+        assert expected in captured.out
 
     # TODO: add test_clean for postgresSQL to see if tables dropped @rehmanis


### PR DESCRIPTION
Associated issue #321 
- now cleans (i.e removes the `migration\` , `shopyo.db`, and `__pycache__`) before initializing the app