### PR TITLE
fix: running test does not clear shopyo.db

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+base: "parent"
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ script:
     - cd shopyo
     - echo 'Running Tests....'
     - coverage run --branch --source . -m pytest
+    - coverage report
 after_success:
     - codecov   # submit coverage

--- a/shopyo/manage.py
+++ b/shopyo/manage.py
@@ -23,7 +23,7 @@ def process(args):
         autoload_models()
         initialise()
     elif args[0] == "clean":
-        clean()
+        clean(app)
     elif args[0] == "runserver":
         runserver()
     elif args[0] == "rundebug":

--- a/shopyo/shopyoapi/cmd.py
+++ b/shopyo/shopyoapi/cmd.py
@@ -7,18 +7,18 @@ import re
 import subprocess
 import sys
 
-from app import app
 from shopyoapi.init import db
 from shopyoapi.uploads import add_admin
 from shopyoapi.uploads import add_setting
 from shopyoapi.uploads import add_uncategorised_category
 from shopyoapi.cmd_helper import remove_pycache
-from shopyoapi.cmd_helper import remove_file_or_dir
+from shopyoapi.cmd_helper import remove_file
+from shopyoapi.cmd_helper import remove_directory
 from .file import trymkdir
 from .file import trymkfile
 
 
-def clean():
+def clean(app):
     """
     Deletes shopyo.db and migrations/ if present in current working directory.
     Deletes all __pycache__ folders starting from current working directory
@@ -26,7 +26,7 @@ def clean():
 
     Parameters
     ----------
-
+        - app: flask app that that need to be cleaned
 
     Returns
     -------
@@ -41,8 +41,8 @@ def clean():
         print("[x] all tables dropped")
 
     remove_pycache(os.getcwd())
-    remove_file_or_dir("shopyo.db")
-    remove_file_or_dir("migrations")
+    remove_file(os.getcwd(), "shopyo.db")
+    remove_directory(os.getcwd(), "migrations")
 
 
 def initialise():

--- a/shopyo/shopyoapi/cmd_helper.py
+++ b/shopyo/shopyoapi/cmd_helper.py
@@ -28,22 +28,6 @@ def remove_pycache(dir_name):
         print("[ ] __pycache__ doesn't exist", file=sys.stderr)
 
 
-def remove_file_or_dir(name):
-    """removes the file or directory
-
-    Args:
-        name (string): file path or directory path to be removed
-    """
-    if os.path.exists(name) and os.path.isdir(name):
-        rmtree(name)
-        print(f"[x] folder '{name}' successfully deleted")
-    elif os.path.exists(name) and not os.path.isdir(name):
-        os.remove(name)
-        print(f"[x] file '{name}' successfully deleted")
-    else:
-        print(f"[ ] file/folder '{name}' doesn't exist")
-
-
 def remove_file(path, filename):
     try:
         os.remove(os.path.join(path, filename))

--- a/shopyo/shopyoapi/cmd_helper.py
+++ b/shopyo/shopyoapi/cmd_helper.py
@@ -1,6 +1,7 @@
 """
 Helper utility functions for commandline api
 """
+import sys
 import os
 from shutil import rmtree
 
@@ -24,7 +25,7 @@ def remove_pycache(dir_name):
     if is_removed:
         print("[x] __pycache__ successfully deleted")
     else:
-        print("[ ] __pycache__ doesn't exist")
+        print("[ ] __pycache__ doesn't exist", file=sys.stderr)
 
 
 def remove_file_or_dir(name):
@@ -41,3 +42,25 @@ def remove_file_or_dir(name):
         print(f"[x] file '{name}' successfully deleted")
     else:
         print(f"[ ] file/folder '{name}' doesn't exist")
+
+
+def remove_file(path, filename):
+    try:
+        os.remove(os.path.join(path, filename))
+        print(f"[x] file '{filename}' successfully deleted")
+    except OSError as e:
+        print(
+            "[ ] unable to delete %s: %s." % (e.filename, e.strerror),
+            file=sys.stderr
+        )
+
+
+def remove_directory(path, directory):
+    try:
+        rmtree(os.path.join(path, directory))
+        print(f"[x] folder '{directory}' successfully deleted")
+    except OSError as e:
+        print(
+            "[ ] unable to delete %s: %s." % (e.filename, e.strerror),
+            file=sys.stderr
+        )

--- a/shopyo/shopyoapi/tests/test_cmd.py
+++ b/shopyo/shopyoapi/tests/test_cmd.py
@@ -5,118 +5,287 @@ Uses pytest with fixture built in fixtures
 """
 import os
 from shopyoapi.cmd import clean
+import pytest
 
 
+@pytest.mark.order("last")
 class TestCommandlineClean:
     """tests the clean command line api function"""
 
-    def test_clean_pycache_present_only_in_cwd(self, tmpdir, capfd):
-        tmpdir.mkdir("__pycache__")
+    def test_clean_pycache_present_only_in_cwd(self, tmpdir, capfd, flask_app):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+            __pycache__/
+                file.pyc
+        """
+        fd = tmpdir.mkdir("__pycache__").join("file.pyc")
+        fd.write("content")
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
             "[x] __pycache__ successfully deleted\n"
-            "[ ] file/folder 'shopyo.db' doesn't exist\n"
-            "[ ] file/folder 'migrations' doesn't exist\n"
+        )
+        expected_err_shopyo_db = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'shopyo.db')}"
+        )
+        expected_err_migrations = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'migrations')}"
         )
 
         assert os.path.exists("__pycache__") is False
-        assert captured.out == expected
+        assert expected_out in captured.out
+        assert expected_err_shopyo_db in captured.err
+        assert expected_err_migrations in captured.err
 
-    def test_clean_pycache_in_one_level_below_cwd(self, tmpdir, capfd):
-        path = tmpdir.mkdir("shopyo")
-        pycache_path = path.mkdir("__pycache__")
+    def test_clean_pycache_in_a_lvl_below_cwd(self, tmpdir, capfd, flask_app):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+            shopyo/
+                __pycache__/
+                    file.pyc
+        """
+        shopyo_path = tmpdir.mkdir("shopyo")
+        pycache_path = shopyo_path.mkdir("__pycache__")
+        pyc = pycache_path.join("file.pyc")
+        pyc.write("content")
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
             "[x] __pycache__ successfully deleted\n"
-            "[ ] file/folder 'shopyo.db' doesn't exist\n"
-            "[ ] file/folder 'migrations' doesn't exist\n"
+        )
+        expected_err_shopyo_db = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'shopyo.db')}"
+        )
+        expected_err_migrations = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'migrations')}"
         )
 
         assert os.path.exists(pycache_path) is False
-        assert captured.out == expected
+        assert expected_out in captured.out
+        assert expected_err_shopyo_db in captured.err
+        assert expected_err_migrations in captured.err
 
-    def test_clean_pycache_in_multiple_levels_below_cwd(self, tmpdir, capfd):
+    def test_clean_pycache_many_lvls_below_cwd(self, tmpdir, capfd, flask_app):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+            shopyo/
+                shopyo/
+                    mod/
+                        box/
+                        __pycache__/
+                            file.pyc
+        """
+
         path = tmpdir.mkdir("shopyo").mkdir("shopyo").mkdir("mod").mkdir("box")
         pycache_path = path.mkdir("__pycache__")
+        pyc = pycache_path.join("file.pyc")
+        pyc.write("content")
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
             "[x] __pycache__ successfully deleted\n"
-            "[ ] file/folder 'shopyo.db' doesn't exist\n"
-            "[ ] file/folder 'migrations' doesn't exist\n"
+        )
+        expected_err_shopyo_db = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'shopyo.db')}"
+        )
+        expected_err_migrations = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'migrations')}"
         )
 
         assert os.path.exists(pycache_path) is False
-        assert captured.out == expected
+        assert expected_out in captured.out
+        assert expected_err_shopyo_db in captured.err
+        assert expected_err_migrations in captured.err
 
-    def test_clean_multiple_pycache_in_nested_directories(self, tmpdir, capfd):
-        path1 = tmpdir.mkdir("__pycache__")
-        path2 = tmpdir.mkdir("shopyo").mkdir("__pycache__")
-        path3 = path2.mkdir("__pycache__")
+    def test_clean_many_pycache_in_nested_dirs(self, tmpdir, capfd, flask_app):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+            __pycache__/
+                file.pyc
+            shopyo/
+                __pycache__
+                    file.pyc
+                module/
+                    __pycache__
+                        file.pyc
+        """
+        pycache_path1 = tmpdir.mkdir("__pycache__")
+        pyc1 = pycache_path1.join("file.pyc")
+        pyc1.write("content")
+        shopyo_path = tmpdir.mkdir("shopyo")
+        pycache_path2 = shopyo_path.mkdir("__pycache__")
+        pyc2 = pycache_path2.join("file.pyc")
+        pyc2.write("content")
+        pycache_path3 = shopyo_path.mkdir("module").mkdir("__pycache__")
+        pyc3 = pycache_path3.join("file.pyc")
+        pyc3.write("content")
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
             "[x] __pycache__ successfully deleted\n"
-            "[ ] file/folder 'shopyo.db' doesn't exist\n"
-            "[ ] file/folder 'migrations' doesn't exist\n"
+        )
+        expected_err_shopyo_db = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'shopyo.db')}"
+        )
+        expected_err_migrations = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'migrations')}"
         )
 
-        assert os.path.exists(path1) is False
-        assert os.path.exists(path2) is False
-        assert os.path.exists(path3) is False
-        assert captured.out == expected
+        assert os.path.exists(pycache_path1) is False
+        assert os.path.exists(pycache_path2) is False
+        assert os.path.exists(pycache_path3) is False
+        assert expected_out in captured.out
+        assert expected_err_shopyo_db in captured.err
+        assert expected_err_migrations in captured.err
 
     def test_no_clean_applied_on_multiple_pycache(self, tmpdir, capfd):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+                __pycache__/
+                shopyo/
+                    __pycache__/
+
+        """
         path1 = tmpdir.mkdir("__pycache__")
         path2 = tmpdir.mkdir("shopyo").mkdir("__pycache__")
-        path3 = path2.mkdir("__pycache__")
 
         assert os.path.exists(path1)
         assert os.path.exists(path2)
-        assert os.path.exists(path3)
 
-    def test_clean_on_shopyo_db_file(self, tmpdir, capfd):
+    def test_clean_on_shopyo_db_file(self, tmpdir, capfd, flask_app):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+            shopyo.db
+        """
         shopyo_db = tmpdir.join("shopyo.db")
         shopyo_db.write("content")
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
-            "[ ] __pycache__ doesn't exist\n"
             "[x] file 'shopyo.db' successfully deleted\n"
-            "[ ] file/folder 'migrations' doesn't exist\n"
+        )
+        expected_err_pycache = (
+            "[ ] __pycache__ doesn't exist\n"
+        )
+        expected_err_migrations = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'migrations')}"
         )
 
         assert os.path.exists(shopyo_db) is False
-        assert captured.out == expected
+        assert expected_out in captured.out
+        assert expected_err_pycache in captured.err
+        assert expected_err_migrations in captured.err
 
-    def test_clean_on_migration_folder(self, tmpdir, capfd):
+    def test_clean_on_migration_folder(self, tmpdir, capfd, flask_app):
+        """
+        run clean on the following test directory:
+
+        <some-unique-tmpdir>/
+            migrations/
+                env.py
+                alembic.ini
+        """
         migrations_path = tmpdir.mkdir("migrations")
+        env = migrations_path.join("env.py")
+        alembic = migrations_path.join("alembic.ini")
+        env.write("content-env")
+        alembic.write("content-alembic")
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
-            "[ ] __pycache__ doesn't exist\n"
-            "[ ] file/folder 'shopyo.db' doesn't exist\n"
             "[x] folder 'migrations' successfully deleted\n"
+        )
+        expected_err_pycache = (
+            "[ ] __pycache__ doesn't exist\n"
+        )
+        expected_err_shopyo_db = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'shopyo.db')}"
         )
 
         assert os.path.exists(migrations_path) is False
-        assert captured.out == expected
+        assert expected_out in captured.out
+        assert expected_err_pycache in captured.err
+        assert expected_err_shopyo_db in captured.err
+
+    def test_clean_on_pycache_shopyo_migration(self, tmpdir, flask_app, capfd):
+        """
+        run clean on the following test directory
+
+        shopyo/
+            shopyo/
+                migrations/
+                    alembic.ini
+                    env.py
+                module1/
+                    __pycache__/
+                        file.pyc
+                module2/
+                    __pycache__/
+                        file.pyc
+                shopyo.db
+        """
+        shopyo_path = tmpdir.mkdir("shopyo").mkdir("shopyo")
+        migrations_path = shopyo_path.mkdir("migrations")
+        env = migrations_path.join("env.py")
+        env.write("content-env")
+        alembic = migrations_path.join("alembic.ini")
+        alembic.write("content-alembic")
+        pycache_path1 = shopyo_path.mkdir("module1").mkdir("__pycache__")
+        pycache_path2 = shopyo_path.mkdir("module2").mkdir("__pycache__")
+        pyc1 = pycache_path1.join("file.pyc")
+        pyc1.write("content")
+        pyc2 = pycache_path2.join("file.pyc")
+        pyc2.write("content")
+        shopyo_db = shopyo_path.join("shopyo.db")
+        shopyo_db.write("content")
+        os.chdir(shopyo_path)
+        clean(flask_app)
+        captured = capfd.readouterr()
+        expected_out = (
+            "[x] all tables dropped\n"
+            "[x] __pycache__ successfully deleted\n"
+            "[x] file 'shopyo.db' successfully deleted\n"
+            "[x] folder 'migrations' successfully deleted\n"
+        )
+
+        assert expected_out == captured.out
+        assert os.path.exists(migrations_path) is False
+        assert os.path.exists(pycache_path1) is False
+        assert os.path.exists(pycache_path2) is False
+        assert os.path.exists(shopyo_db) is False
 
     def test_no_clean_on_shopyo_and_migrations(self, tmpdir):
+        """
+        run test on the following test directory:
+
+        <some-unique-tmpdir>/
+            migrations/
+            shopyo.db
+        """
         migrations_path = tmpdir.mkdir("migrations")
         shopyo_db = tmpdir.join("shopyo.db")
         shopyo_db.write("content")
@@ -124,17 +293,26 @@ class TestCommandlineClean:
         assert os.path.exists(migrations_path)
         assert os.path.exists(shopyo_db)
 
-    def test_clean_on_no_files_to_clean(self, tmpdir, capfd):
+    def test_clean_on_no_files_to_clean(self, tmpdir, capfd, flask_app):
         os.chdir(tmpdir)
-        clean()
+        clean(flask_app)
         captured = capfd.readouterr()
-        expected = (
+        expected_out = (
             "[x] all tables dropped\n"
+        )
+        expected_err_pycache = (
             "[ ] __pycache__ doesn't exist\n"
-            "[ ] file/folder 'shopyo.db' doesn't exist\n"
-            "[ ] file/folder 'migrations' doesn't exist\n"
+        )
+        expected_err_shopyo_db = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'shopyo.db')}"
+        )
+        expected_err_migrations = (
+            f"[ ] unable to delete {os.path.join(tmpdir, 'migrations')}"
         )
 
-        assert captured.out == expected
+        assert expected_out in captured.out
+        assert expected_err_pycache in captured.err
+        assert expected_err_shopyo_db in captured.err
+        assert expected_err_migrations in captured.err
 
     # TODO: add test_clean for postgresSQL to see if tables dropped @rehmanis

--- a/shopyo/shopyoapi/tests/test_models.py
+++ b/shopyo/shopyoapi/tests/test_models.py
@@ -19,7 +19,6 @@ class ExampleUserModel(PkModel, UserMixin):
     email = db.Column(db.String(120), unique=True, nullable=False)
 
 
-@pytest.mark.usefixtures("db_session")
 class TestPKModel:
     """Tests all functions of PKModel"""
     def test_get_by_id(self):
@@ -46,7 +45,6 @@ class TestPKModel:
         assert result_str.username == expected.username
 
 
-@pytest.mark.usefixtures("db_session")
 class TestCRUDMixin:
     """Test class for testing all CRUD functions"""
 


### PR DESCRIPTION
fixes #344:
- bug was in the [`shopyoapi/shopyo/cmd.py`](https://github.com/Abdur-rahmaanJ/shopyo/blob/dev/shopyo/shopyoapi/cmd.py#L38) clean() function. Was mixing development and testing app due to the following following line:
```python

from app import app

def clean():
    with app.test_request_context():
        db.drop_all()
        db.engine.execute('DROP TABLE IF EXISTS alembic_version;')
        print("[x] all tables dropped")
        
        # rest of the code
```
- fix was to pass app as a function argument as below:
```python
def clean(app):
    """
    Deletes shopyo.db and migrations/ if present in current working directory.
    Deletes all __pycache__ folders starting from current working directory
    all the way to leaf directory.

    Parameters
    ----------
        - app: flask app that that need to be cleaned

    Returns
    -------
    None
        ...

    """
    # getting app context creates the shopyo.db file even if it is not present
    with app.test_request_context():
        db.drop_all()
        db.engine.execute('DROP TABLE IF EXISTS alembic_version;')
        print("[x] all tables dropped")

    remove_pycache(os.getcwd())
    remove_file(os.getcwd(), "shopyo.db")
    remove_directory(os.getcwd(), "migrations")
```

- however, this fix introduces another interesting issue. Since clean calls `db.drop_all()`, if we run any tests after testing clean function, test that use any models that were preloaded will crash. For now to fix this, I added `@pytest.mark.order("last")` to the clean test class to make sure it runs at the end. Better approach would be to restore the db again after the clean test. This can be done by adding a fixture that yields before the test and restores after the clean test functions. 
- split `remove_file_or_dir` into two functions and use try catch block. It might fix the #339 or atleast not throw the exception trace
- made the tests more robust and readable.