### PR TITLE
feat: add email confirmation disable option in configs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,30 @@
+name: Shopyo testing workflow
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8' ]
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Run pytests and generate coverage report
+        run: |
+          pip install -U pip
+          pip install -r requirements.txt -r dev_requirements.txt
+          sphinx-build -b html sphinx_source docs
+          cd shopyo
+          echo 'Running Tests....'
+          coverage run --branch --source . -m pytest
+          coverage report
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+
+
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - python --version
     - pip install -U pip
 install:
-    - pip install -r requirement.txt -r dev_requirements.txt
+    - pip install -r requirements.txt -r dev_requirements.txt
 script:
     - sphinx-build -b html sphinx_source docs
     - cd shopyo

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,7 @@ parsers:
       loop: yes
       method: no
       macro: no
-
+base: "parent"
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,12 @@ codecov:
 
 coverage:
   precision: 2
-  round: down
-  range: "70...100"
+  round: up
+  range: "65...100"
+  status:
+    project:
+      default:
+        threshold: 0.1%
 
 parsers:
   gcov:
@@ -13,8 +17,8 @@ parsers:
       loop: yes
       method: no
       macro: no
-base: "parent"
+
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
-  require_changes: no 
+  require_changes: no

--- a/shopyo/config_demo.py
+++ b/shopyo/config_demo.py
@@ -35,7 +35,8 @@ class DevelopmentConfig(Config):
     ENV = "development"
     DEBUG = True
     LOGIN_DISABLED = False
-
+    # control email confirmation for user registration
+    EMAIL_CONFIRMATION_DISABLED = False
     # flask-mailman configs
     MAIL_SERVER = 'smtp.googlemail.com'
     MAIL_PORT = 465
@@ -57,7 +58,8 @@ class TestingConfig(Config):
     SERVER_NAME = "localhost.com"
     BCRYPT_LOG_ROUNDS = 4
     WTF_CSRF_ENABLED = False
-
+    # control email confirmation for user registration
+    EMAIL_CONFIRMATION_DISABLED = False
     # flask-mailman configs
     MAIL_BACKEND = "console"
     MAIL_USERNAME = "shopyofrom@test.com"

--- a/shopyo/modules/box__default/auth/email.py
+++ b/shopyo/modules/box__default/auth/email.py
@@ -42,7 +42,7 @@ def send_async_email(to, subject, template, from_email=None, **kwargs):
     email template files exits
 
     Args:
-        to (String): receipient of the email
+        to (String): recipient of the email
         subject (String): subject of the email
         template (String): template file path to be used in email body
         from_email (String, optional): sender of the email. If not set

--- a/shopyo/modules/box__default/auth/models.py
+++ b/shopyo/modules/box__default/auth/models.py
@@ -39,15 +39,24 @@ class AnonymousUser(AnonymousUserMixin):
         self.username = "guest"
         self.email = "<anonymous-user-no-email>"
 
-    # ALL PROPERTIES SET TO TRUE TO MAKE TESTING EASIER
-    # UPDATE THIS IN PRODUCTION
     @property
     def is_email_confirmed(self):
-        return True
+        is_disabled = False
+
+        if "EMAIL_CONFIRMATION_DISABLED" in current_app.config:
+            is_disabled = current_app.config["EMAIL_CONFIRMATION_DISABLED"]
+
+            if is_disabled is not True:
+                is_disabled = False
+
+        return is_disabled
 
     @property
     def is_admin(self):
-        return True
+        return False
+
+    def __repr__(self):
+        return f"<AnonymousUser {self.username}>"
 
 
 login_manager.anonymous_user = AnonymousUser

--- a/shopyo/modules/box__default/auth/tests/conftest.py
+++ b/shopyo/modules/box__default/auth/tests/conftest.py
@@ -9,26 +9,25 @@ import pytest
 @pytest.fixture
 def email_config(request, flask_app):
     """
-    pytest fixture for temporally changing the flaskmail-man configs
+    pytest fixture for temporally changing the email related configs
+    To remove the config pass "remove" in @pytest.parameterize. For
+    setting value to the config pass the actual value. See test_email.py
+    for usage
 
     Args:
         request (pytest obj): a built in by pytest object used to read
             incoming fixture arguments
         flask_app (flask app): flask app fixture
 
-    Raises:
-        ValueError: if fixture called with config type other than
-            'remove' or 'none'. See test_email.py for usage
     """
-    config_name, config_type = request.param
+    config_name, config_val = request.param
     old = flask_app.config[config_name]
 
-    if config_type == 'remove':
+    if config_val == "remove":
         del flask_app.config[config_name]
-    elif config_type == 'none':
-        flask_app.config[config_name] = None
     else:
-        raise ValueError('unknown config type')
+        flask_app.config[config_name] = config_val
+        print(f"\n{config_name}: {config_val}\n")
 
     yield
     flask_app.config[config_name] = old

--- a/shopyo/modules/box__default/auth/tests/test_auth_functional.py
+++ b/shopyo/modules/box__default/auth/tests/test_auth_functional.py
@@ -75,19 +75,52 @@ class TestAuthEndpoints:
         assert response.status_code == 200
         assert request.path == url_for("auth.register")
 
-    def test_user_is_registered_on_valid_form_submit(self, test_client, capfd):
+    @pytest.mark.parametrize(
+        'email_config',
+        [
+            ("EMAIL_CONFIRMATION_DISABLED", True),
+        ],
+        indirect=True
+    )
+    def test_user_confirmed_if_email_disabled(self, test_client, email_config):
         data = {
             "email": "test@gmail.com",
             "password": "password",
             "confirm": "password"
         }
-
         response = test_client.post(
             f"{module_info['url_prefix']}/register",
             data=data,
             follow_redirects=True,
         )
+        user = User.query.filter(User.email == "test@gmail.com").scalar()
 
+        assert response.status_code == 200
+        assert request.path == url_for("dashboard.index")
+        assert user.is_email_confirmed is True
+
+    @pytest.mark.parametrize(
+        'email_config',
+        [
+            ("EMAIL_CONFIRMATION_DISABLED", "remove"),
+            ("EMAIL_CONFIRMATION_DISABLED", False),
+            ("EMAIL_CONFIRMATION_DISABLED", None),
+        ],
+        indirect=True
+    )
+    def test_user_is_registered_on_valid_form_submit(
+        self, test_client, capfd, email_config
+    ):
+        data = {
+            "email": "test@gmail.com",
+            "password": "password",
+            "confirm": "password"
+        }
+        response = test_client.post(
+            f"{module_info['url_prefix']}/register",
+            data=data,
+            follow_redirects=True,
+        )
         # Not very happy with this solution. Need a better
         # way to wait for the email thread to join with main
         # thread before reading the email written to stdout @rehmanis
@@ -98,11 +131,13 @@ class TestAuthEndpoints:
 
         user = User.query.filter(User.email == "test@gmail.com").scalar()
 
+        assert response.status_code == 200
+        assert request.path == url_for("auth.unconfirmed")
+        assert b"A confirmation email has been sent via email" in response.data
         assert "test@gmail.com" in captured.out
         assert "Welcome to Shopyo" in captured.out
-        assert response.status_code == 200
         assert user is not None
-        assert request.path == url_for("auth.unconfirmed")
+        assert user.is_email_confirmed is False
 
     @pytest.mark.usefixtures("login_non_admin_user")
     def test_user_not_confirmed_for_already_confirmed_user(self, test_client):

--- a/shopyo/modules/box__default/auth/tests/test_auth_models.py
+++ b/shopyo/modules/box__default/auth/tests/test_auth_models.py
@@ -43,12 +43,34 @@ class TestAnonymousUser:
     def test_anonymous_user_is_admin(self):
         user = AnonymousUser()
 
-        assert user.is_admin
+        assert user.is_admin is False
 
-    def test_anonymous_user_has_email_confirmed(self):
+    @pytest.mark.parametrize(
+        'email_config',
+        [
+            ("EMAIL_CONFIRMATION_DISABLED", "remove"),
+            ("EMAIL_CONFIRMATION_DISABLED", False),
+            ("EMAIL_CONFIRMATION_DISABLED", None),
+            ("EMAIL_CONFIRMATION_DISABLED", "random string"),
+        ],
+        indirect=True
+    )
+    def test_anonymous_user_email_confirmed_disabled(self, email_config):
         user = AnonymousUser()
 
-        assert user.is_email_confirmed
+        assert user.is_email_confirmed is False
+
+    @pytest.mark.parametrize(
+        'email_config',
+        [
+            ("EMAIL_CONFIRMATION_DISABLED", True),
+        ],
+        indirect=True
+    )
+    def test_anonymous_user_has_email_confirmed_enabled(self, email_config):
+        user = AnonymousUser()
+
+        assert user.is_email_confirmed is True
 
     def test_anonymous_username_is_set(self):
         user = AnonymousUser()
@@ -59,6 +81,12 @@ class TestAnonymousUser:
         user = AnonymousUser()
 
         assert bool(user.email)
+
+    def test_anonymous_user_representation(self):
+
+        user = AnonymousUser()
+
+        assert repr(user) == "<AnonymousUser guest>"
 
 
 class TestUser:

--- a/shopyo/modules/box__default/auth/tests/test_email.py
+++ b/shopyo/modules/box__default/auth/tests/test_email.py
@@ -13,7 +13,7 @@ from modules.box__default.auth.models import User
 
 @pytest.mark.parametrize(
     'email_config',
-    [("MAIL_DEFAULT_SENDER", "remove"), ("MAIL_DEFAULT_SENDER", "none")],
+    [("MAIL_DEFAULT_SENDER", "remove"), ("MAIL_DEFAULT_SENDER", None)],
     indirect=True
 )
 def test_send_email_with_no_default_sender(capfd, email_config):
@@ -33,8 +33,8 @@ def test_send_email_with_no_default_sender(capfd, email_config):
     [
         ("MAIL_USERNAME", "remove"),
         ("MAIL_PASSWORD", "remove"),
-        ("MAIL_USERNAME", "none"),
-        ("MAIL_PASSWORD", "none"),
+        ("MAIL_USERNAME", None),
+        ("MAIL_PASSWORD", None),
     ],
     indirect=True
 )
@@ -55,18 +55,22 @@ def test_send_email_with_no_username_or_password_set(capfd, email_config):
 
 
 def test_send_email_using_template_on_valid_credentials(capfd):
-    user = User.create(email="test@gmail.com", password="pass")
+    user = User.create(email="to@gmail.com", password="pass")
     token = "sometoken"
     template = "auth/emails/activate_user"
     subject = "Please confirm your email"
+    from_email = "from@gmail.com"
     context = {"token": token, "user": user}
-    thread = send_async_email(user.email, subject, template, **context)
+    thread = send_async_email(
+        user.email, subject, template, from_email=from_email, **context
+    )
     thread.join()
     captured = capfd.readouterr()
 
     assert "Please confirm your email" in captured.out
     assert "sometoken" in captured.out
-    assert "test@gmail.com" in captured.out
+    assert "to@gmail.com" in captured.out
+    assert "from@gmail.com" in captured.out
     assert "Welcome to Shopyo" in captured.out
     assert "To confirm your account please click on" in captured.out
     assert "The Shopyo Team" in captured.out

--- a/shopyo/modules/box__default/auth/view.py
+++ b/shopyo/modules/box__default/auth/view.py
@@ -1,11 +1,13 @@
 import json
 import os
+import datetime
 from flask import Blueprint
 from flask import flash
 from flask import redirect
 from flask import render_template
 from flask import request
 from flask import url_for
+from flask import current_app
 from flask_login import current_user
 from flask_login import login_required
 from flask_login import login_user
@@ -45,12 +47,26 @@ def register():
         password = reg_form.password.data
         user = User.create(email=email, password=password)
         login_user(user)
-        token = user.generate_confirmation_token()
-        template = "auth/emails/activate_user"
-        subject = "Please confirm your email"
-        context.update({"token": token, "user": user})
-        send_async_email(email, subject, template, **context)
-        flash(notify_success("A confirmation email has been sent via email."))
+
+        is_disabled = False
+
+        if "EMAIL_CONFIRMATION_DISABLED" in current_app.config:
+            is_disabled = current_app.config["EMAIL_CONFIRMATION_DISABLED"]
+
+        if is_disabled is True:
+            user.is_email_confirmed = True
+            user.email_confirm_date = datetime.datetime.now()
+            user.update()
+        else:
+            token = user.generate_confirmation_token()
+            template = "auth/emails/activate_user"
+            subject = "Please confirm your email"
+            context.update({"token": token, "user": user})
+            send_async_email(email, subject, template, **context)
+            flash(
+                notify_success("A confirmation email has been sent via email.")
+            )
+
         return redirect(url_for("dashboard.index"))
 
     context["form"] = reg_form
@@ -120,16 +136,17 @@ def shop_login():
     context = {}
     login_form = LoginForm()
     context["form"] = login_form
-    if request.method == "POST":
-        if login_form.validate_on_submit():
-            email = login_form.email.data
-            password = login_form.password.data
-            user = User.query.filter_by(email=email).first()
-            if user is None or not user.check_password(password):
-                flash(notify_danger("please check your user id and password"))
-                return redirect(url_for("shop.checkout"))
-            login_user(user)
+
+    if login_form.validate_on_submit():
+        email = login_form.email.data
+        password = login_form.password.data
+        user = User.query.filter_by(email=email).first()
+        if user is None or not user.check_password(password):
+            flash(notify_danger("please check your user id and password"))
             return redirect(url_for("shop.checkout"))
+        login_user(user)
+        return redirect(url_for("shop.checkout"))
+
     return render_template("auth/shop_login.html", **context)
 
 


### PR DESCRIPTION
closes #388 
- add `EMAIL_CONFIRMATION_DISABLED` option in config. If this config is not present or set to any value other than True, then email confirmation is enabled by default.