### PR TITLE
Closed #415. Press Ctrl+C to quit throws an error

### DIFF
--- a/shopyo/manage.py
+++ b/shopyo/manage.py
@@ -82,6 +82,9 @@ def process(args):
             raise e
     else:
         print("Command not recognised")
+    
+    # This will be printed on exit
+    print("See you soon!!!")
 
 
 if __name__ == "__main__":

--- a/shopyo/manage.py
+++ b/shopyo/manage.py
@@ -33,7 +33,7 @@ def process(args):
     elif args[0] == "rundebug":
         app.run(debug=True, host="0.0.0.0")
         try:
-            if args[1]:
+            if len(args) > 2 and args[1]:
                 app.run(debug=True, host="0.0.0.0", port=int(args[1]))
         except IndexError as e:
             raise e


### PR DESCRIPTION
Description
Press Ctrl+C to quit throws an error
Index out of range error

Motivation:
Bug Fix
Handling Index Out of Range in better way

Testing
Running the app and then using Ctrl+C to quit it
Expected result no error should be thrown

Type of Change
Bug fix (non-breaking change which fixes an issue)
This wasn't breaking anything
But it's better to handle it in a proper way