### PR TITLE
Fix Issue #413

### DIFF
--- a/shopyo/__main__.py
+++ b/shopyo/__main__.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 from pathlib import Path
 

--- a/shopyo/__main__.py
+++ b/shopyo/__main__.py
@@ -11,6 +11,8 @@ from .shopyoapi.info import printinfo
 from .shopyoapi.cmd_helper import tryrmtree
 from .shopyoapi.cmd_helper import tryrmfile
 
+from manage import process
+
 dirpath = Path(__file__).parent.absolute()
 dirpathparent = Path(__file__).parent.parent.absolute()
 
@@ -406,16 +408,15 @@ def main():
     if len(args) == 1:
         printinfo()
         print("No arguments supplied")
-    if args[1] == "new" and len(args) == 3:
+    elif len(args) == 3 and args[1] == "new" and args[2]:
         printinfo()
         new_project(args[2])
     else:
         if not is_venv():
             print("Please use Shopyo in a virtual environment for this command")
             sys.exit()
-        torun = [sys.executable, "manage.py"] + args[1:]
-        subprocess.run(torun, stdout=subprocess.PIPE)
-
+        process(args[1:])
+        
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Title:
Fix shopyo initialise does not give same console output as python manage.py initialise #413

Description:
Fix shopyo initialise does not give same console output as python manage.py initialise #413

Motivation and Context
Fix shopyo initialise does not give same console output as python manage.py initialise #413

How Has This Been Tested?
Compared the output of python manage.py initialise and python . initialse

Types of changes
 Bug fix (non-breaking change which fixes an issue)

![image3](https://user-images.githubusercontent.com/25884741/109302900-f0ac9300-785f-11eb-8d59-49f7f91b410b.png)
