### PR TITLE
Added shopyo path to requirements and dev_requirements in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ skip_missing_interpreters=true
 # test setup according to https://www.appinv.science/shopyo/testing.html
 changedir = shopyo
 deps = 
-    pytest 
-    pytest-order
+    #setuptools
+    -rshopyo/requirements.txt
+    -rshopyo/dev_requirements.txt
 commands = python -m pytest  {posargs}


### PR DESCRIPTION
This fix works on my machine but please double check. setuptools in the deps appears to be surplus to requirements.