### PR TITLE
TEST: shopyo initialise after new

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 [pytest]
 env_files =
     .test.prod.env
+
+markers =
+    cli_unit: unit cli tests
+    cli_integration: marks tests as integrations tests which are slow (deselect with '-m "not cli_intergration"')

--- a/shopyo/api/cli.py
+++ b/shopyo/api/cli.py
@@ -448,7 +448,6 @@ def new(projname, verbose):
     click.echo(f"[x] Project {projname} created successfully!\n")
 
 
-
 def shopyo_cli():
     arguments = sys.argv[1:]
     if len(arguments) > 0:
@@ -463,6 +462,7 @@ def shopyo_cli():
                 app.run(debug=False)
     else:
         cli()
+
 
 if __name__ == '__main__':
     shopyo_cli()

--- a/shopyo/api/tests/conftest.py
+++ b/shopyo/api/tests/conftest.py
@@ -4,6 +4,25 @@ All pytest fixtures local only to the api/tests are placed here
 """
 import pytest
 import os
+import shutil
+import tempfile
+
+
+@pytest.fixture
+def cleandir():
+    old_cwd = os.getcwd()
+    newpath = tempfile.mkdtemp()
+    os.chdir(newpath)
+    yield
+    os.chdir(old_cwd)
+    shutil.rmtree(newpath)
+
+
+@pytest.fixture
+def restore_cwd():
+    old = os.getcwd()
+    yield
+    os.chdir(old)
 
 
 @pytest.fixture
@@ -39,18 +58,21 @@ def fake_foo_proj(tmp_path):
         built in pytest fixture which will provide a temporary directory unique
         to the test invocation, created in the base temporary directory.
     """
+    # create the tmp_path/foo/foo
     project_path = tmp_path / "foo" / "foo"
     project_path.mkdir(parents=True)
+    # create the static and modules inside foo/foo
     static_path = project_path / "static"
     module_path = project_path / "modules"
+    static_path.mkdir()
+    module_path.mkdir()
+    # create the dummy boxes and modules
     demo_path = module_path / "box__bizhelp/demo/demo.py"
     foo_path = module_path / "box__default/foo/static/foo.css"
     zoo_path = module_path / "box__default/zoo/static/zoo.css"
     foozoo_path = module_path / "box__default/foozoo/foozoo.py"
     bar_path = module_path / "bar/static/bar.css"
     baz_path = module_path / "baz/model/baz.py"
-    static_path.mkdir()
-    module_path.mkdir()
     demo_path.parent.mkdir(parents=True)
     foo_path.parent.mkdir(parents=True)
     zoo_path.parent.mkdir(parents=True)
@@ -63,5 +85,9 @@ def fake_foo_proj(tmp_path):
     foozoo_path.write_text("foozoo")
     bar_path.write_text("bar")
     baz_path.write_text("baz")
+    # save cwd and chage to test project directory
+    old = os.getcwd()
     os.chdir(project_path)
     yield project_path
+    # restore old cwd directory
+    os.chdir(old)

--- a/shopyo/api/tests/test_cli.py
+++ b/shopyo/api/tests/test_cli.py
@@ -4,6 +4,8 @@ from click.testing import CliRunner
 from shopyo.api.cli import cli
 from shopyo.api.constants import SEP_CHAR, SEP_NUM
 
+pytestmark = pytest.mark.cli_unit
+
 
 @pytest.fixture(scope='session')
 def cli_runner():
@@ -17,6 +19,7 @@ def cli_runner():
     return cli_main
 
 
+@pytest.mark.usefixtures("restore_cwd")
 class TestCliCreateBox:
     """test the create_box command line api function"""
 
@@ -46,6 +49,7 @@ class TestCliCreateBox:
         assert expected in result.output
 
 
+@pytest.mark.usefixtures("restore_cwd")
 @pytest.mark.order("last")
 class TestCliClean:
     """tests the clean command line api function"""
@@ -360,6 +364,7 @@ class TestCliClean:
     # TODO: add test_clean for MySQL to see if tables dropped @rehmanis
 
 
+@pytest.mark.usefixtures("restore_cwd")
 class TestCliNew:
 
     @pytest.mark.parametrize("proj,parent", [("", "foo"), ("bar", "")])

--- a/shopyo/api/tests/test_cli.py
+++ b/shopyo/api/tests/test_cli.py
@@ -9,11 +9,11 @@ pytestmark = pytest.mark.cli_unit
 
 @pytest.fixture(scope='session')
 def cli_runner():
-    """Fixture that returns a helper function to run the cookiecutter cli."""
+    """Fixture that returns a helper function to run the shopyo cli."""
     runner = CliRunner()
 
     def cli_main(*cli_args, **cli_kwargs):
-        """Run cookiecutter cli main with the given args."""
+        """Run shopyo cli main with the given args."""
         return runner.invoke(cli, cli_args, **cli_kwargs)
 
     return cli_main

--- a/shopyo/api/tests/test_cli_integration.py
+++ b/shopyo/api/tests/test_cli_integration.py
@@ -1,0 +1,67 @@
+from shutil import copytree
+import subprocess
+import pytest
+import sys
+import os
+from shopyo import __version__
+
+
+pytestmark = pytest.mark.cli_integration
+
+
+@pytest.mark.usefixtures("restore_cwd")
+def test_initialise_after_new(tmp_path):
+    """run shopyo new inside a tmp directory foo,
+    create a venv, install the shopyo.tar.gz dependencies,
+    run `shopyo new` and then run `shopyo initialise`.
+    """
+
+    # go one level up to the cwd so we are are the root where
+    # setup.py exits
+    os.chdir("../")
+    # create the dist folder with shoypo-<version>.tar.gz file
+    subprocess.check_call([sys.executable, "setup.py", "sdist"])
+    # store all path names to be used later
+    dist_path = os.path.join(os.getcwd(), "dist")
+    shopyo_dist_name = f"shopyo-{__version__}.tar.gz"
+    project_path = tmp_path / "foo"
+    # copy the shopyo dist to the test project path
+    copytree(dist_path, os.path.join(project_path, "dist"))
+    # change cwd to that of test project
+    os.chdir(project_path)
+    # create a new virtual environment(venv)
+    subprocess.check_call([sys.executable, "-m", "venv", "env"])
+    # store path for python and shopyo executable of venv for the case when OS
+    #  is Unix
+    python_env = os.path.join(os.getcwd(), "env", "bin", "python")
+    shopyo_env = os.path.join(os.getcwd(), "env", "bin", "shopyo")
+    # if OS is Windows, update the python and shopyo executable
+    if sys.platform == "win32":
+        python_env = os.path.join(os.getcwd(), "env", "Scripts", "python")
+        shopyo_env = os.path.join(os.getcwd(), "env", "Scripts", "shopyo")
+    # update pip of venv
+    subprocess.check_call(
+        [python_env, "-m", "pip", "install", "--upgrade", "pip"]
+    )
+    # install the shopyo package from dist added earlier
+    subprocess.check_call(
+        [
+            python_env,
+            "-m",
+            "pip",
+            "install",
+            os.path.join("dist", shopyo_dist_name)
+        ]
+    )
+    # run shopyo help command followed by new command
+    subprocess.check_call(["shopyo", "--help"])
+    subprocess.check_call([shopyo_env, "new"])
+    # change the cwd to the newly created shopyo project
+    os.chdir(os.path.join(project_path, "foo"))
+    # initialise the project
+    subprocess.check_call(
+        [shopyo_env, "initialise"]
+    )
+
+    assert os.path.exists("shopyo.db")
+    assert os.path.exists("migrations")

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ skip_missing_interpreters=true
 
 [testenv]
 changedir = shopyo
-deps = 
+deps =
     #setuptools
     -rrequirements/tests.txt
-commands = 
+commands =
     coverage run --branch --source=. -m pytest {posargs}
     coverage report


### PR DESCRIPTION
make sure `shopyo initialise` works after running `shopyo new`. This test will be modified/moved when adding shopyo cookiecutter but for now it make sure all cli works. The individual test is quite slow (1-2min) but needed.

closes #490